### PR TITLE
Modernize Deno ts/ modules (0.1.0, additive)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,26 @@ jobs:
       - name: Test 🧪
         run: npm test
 
+  deno:
+    name: Deno modules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Setup deno 🦕
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      # Only the 0.1.0 module versions are checked/tested; older version
+      # directories are frozen published bytes targeting retired APIs.
+      - name: Type check 🧐
+        run: deno check ts/openai/0.1.0/*.ts ts/serverless-workers/0.1.0/*.ts ts/initiate-http/0.1.0/*.ts
+
+      - name: Test 🧪
+        run: deno test ts/openai/0.1.0/ ts/serverless-workers/0.1.0/ ts/initiate-http/0.1.0/
+
   url-contract:
     name: URL contract
     runs-on: ubuntu-latest

--- a/ts/initiate-http/0.1.0/demo.ts
+++ b/ts/initiate-http/0.1.0/demo.ts
@@ -1,0 +1,10 @@
+import initiateHTTP, { FetchEvent } from "./mod.ts";
+initiateHTTP(8080);
+addEventListener("fetch", (event: Event): void => {
+  const fetchEvent = event as FetchEvent;
+  fetchEvent.respondWith(
+    new Response("hidey how?", {
+      status: 200,
+    }),
+  );
+});

--- a/ts/initiate-http/0.1.0/deno.json
+++ b/ts/initiate-http/0.1.0/deno.json
@@ -1,0 +1,11 @@
+{
+  "name": "@johnhenry/initiate-http",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "tasks": {
+    "check": "deno check mod.ts demo.ts mod.test.ts",
+    "test": "deno test"
+  }
+}

--- a/ts/initiate-http/0.1.0/mod.test.ts
+++ b/ts/initiate-http/0.1.0/mod.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for initiate-http. The event dispatch mechanism is tested
+ * directly — no server is started and no network access is needed.
+ */
+import { dispatchFetchEvent, FetchEvent } from "./mod.ts";
+
+const assert = (condition: boolean, message: string) => {
+  if (!condition) throw new Error(`assertion failed: ${message}`);
+};
+const assertEquals = (actual: unknown, expected: unknown) => {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) throw new Error(`expected ${e}, got ${a}`);
+};
+
+Deno.test("FetchEvent exposes its request", () => {
+  const request = new Request("http://localhost/hello");
+  const event = new FetchEvent(request, () => {});
+  assertEquals(event.type, "fetch");
+  assert(event.request === request, "request should round-trip");
+  assertEquals(event.responded, false);
+});
+
+Deno.test("respondWith resolves the dispatched request", async () => {
+  const target = new EventTarget();
+  target.addEventListener("fetch", (event) => {
+    const fetchEvent = event as FetchEvent;
+    fetchEvent.respondWith(
+      new Response(`hello ${new URL(fetchEvent.request.url).pathname}`, {
+        status: 200,
+      }),
+    );
+  });
+  const response = await dispatchFetchEvent(
+    new Request("http://localhost/world"),
+    target,
+  );
+  assertEquals(response.status, 200);
+  assertEquals(await response.text(), "hello /world");
+});
+
+Deno.test("respondWith accepts a promise of a response", async () => {
+  const target = new EventTarget();
+  target.addEventListener("fetch", (event) => {
+    (event as FetchEvent).respondWith(
+      Promise.resolve(new Response("async", { status: 201 })),
+    );
+  });
+  const response = await dispatchFetchEvent(
+    new Request("http://localhost/"),
+    target,
+  );
+  assertEquals(response.status, 201);
+  assertEquals(await response.text(), "async");
+});
+
+Deno.test("unhandled events resolve with a 501 response", async () => {
+  const response = await dispatchFetchEvent(
+    new Request("http://localhost/nobody-home"),
+    new EventTarget(),
+  );
+  assertEquals(response.status, 501);
+});
+
+Deno.test("calling respondWith twice throws InvalidStateError", () => {
+  const event = new FetchEvent(new Request("http://localhost/"), () => {});
+  event.respondWith(new Response("first"));
+  let thrown: unknown;
+  try {
+    event.respondWith(new Response("second"));
+  } catch (error) {
+    thrown = error;
+  }
+  assert(thrown instanceof DOMException, "should throw DOMException");
+  assertEquals((thrown as DOMException).name, "InvalidStateError");
+});

--- a/ts/initiate-http/0.1.0/mod.ts
+++ b/ts/initiate-http/0.1.0/mod.ts
@@ -1,0 +1,80 @@
+/**
+ * initiate-http — serve HTTP by listening for service-worker-style
+ * "fetch" events on globalThis, powered by Deno.serve.
+ *
+ * The default export starts a server; each incoming request is dispatched
+ * as a {@linkcode FetchEvent} whose listener responds via
+ * `event.respondWith(response)` — the same shape as the service worker /
+ * Cloudflare Workers API.
+ */
+
+/** A service-worker-style fetch event carrying a Request. */
+export class FetchEvent extends Event {
+  #request: Request;
+  #respond: (response: Response | Promise<Response>) => void;
+  #responded = false;
+
+  constructor(
+    request: Request,
+    respond: (response: Response | Promise<Response>) => void,
+  ) {
+    super("fetch");
+    this.#request = request;
+    this.#respond = respond;
+  }
+
+  get request(): Request {
+    return this.#request;
+  }
+
+  /** Whether respondWith has already been called. */
+  get responded(): boolean {
+    return this.#responded;
+  }
+
+  respondWith(response: Response | Promise<Response>): void {
+    if (this.#responded) {
+      throw new DOMException(
+        "respondWith() has already been called",
+        "InvalidStateError",
+      );
+    }
+    this.#responded = true;
+    this.#respond(response);
+  }
+}
+
+/**
+ * Dispatch a request as a FetchEvent on a target (globalThis by default)
+ * and resolve with the response supplied via respondWith. If no listener
+ * responds synchronously, resolves with a 501 response.
+ */
+export const dispatchFetchEvent = (
+  request: Request,
+  target: EventTarget = globalThis,
+): Promise<Response> =>
+  new Promise<Response>((resolve) => {
+    const event = new FetchEvent(request, resolve);
+    target.dispatchEvent(event);
+    if (!event.responded) {
+      resolve(new Response("Not Implemented", { status: 501 }));
+    }
+  });
+
+/**
+ * Start an HTTP server that dispatches "fetch" events on globalThis.
+ * Returns the underlying Deno.HttpServer (await `.finished`, or call
+ * `.shutdown()` to stop).
+ */
+export default (
+  port = 8080,
+  options: {
+    hostname?: string;
+    signal?: AbortSignal;
+    onListen?: (localAddr: Deno.NetAddr) => void;
+  } = {},
+): Deno.HttpServer<Deno.NetAddr> =>
+  Deno.serve(
+    { port, ...options },
+    (request: Request) => dispatchFetchEvent(request),
+  );

--- a/ts/initiate-http/0.1.0/readme.md
+++ b/ts/initiate-http/0.1.0/readme.md
@@ -1,0 +1,42 @@
+# initiate-http
+
+Serve HTTP in [Deno](https://deno.com) using service-worker-style global
+`fetch` events. Calling the default export starts a server (via
+`Deno.serve`); each incoming request is dispatched on `globalThis` as a
+`FetchEvent`, and listeners reply with `event.respondWith(response)` — the
+same shape as the service worker and Cloudflare Workers APIs.
+
+Version [0.0.0](../0.0.0/mod.ts) used the long-removed `Deno.serveHttp`
+connection API; 0.1.0 is a rewrite on modern `Deno.serve`.
+
+## usage
+
+```javascript
+import initiateHTTP, {
+  FetchEvent,
+} from "https://johnhenry.github.io/lib/ts/initiate-http/0.1.0/mod.ts";
+
+initiateHTTP(8080);
+
+addEventListener("fetch", (event) => {
+  event.respondWith(new Response("hidey how?", { status: 200 }));
+});
+```
+
+Run the included demo:
+
+```sh
+deno run --allow-net https://johnhenry.github.io/lib/ts/initiate-http/0.1.0/demo.ts
+```
+
+Requests are answered with `501 Not Implemented` when no listener responds.
+`dispatchFetchEvent(request, target?)` is also exported for dispatching
+against a custom `EventTarget` (useful for testing).
+
+## testing
+
+Tests exercise the event dispatch directly — no network access needed:
+
+```sh
+deno task test
+```

--- a/ts/openai/0.1.0/cli.ts
+++ b/ts/openai/0.1.0/cli.ts
@@ -1,0 +1,125 @@
+/**
+ * openai — a small command line tool for the OpenAI API.
+ *
+ * Usage:
+ *   deno run --allow-net --allow-env cli.ts chat "Say hello" [--model=gpt-4o-mini] [--system=...] [--no-stream]
+ *   deno run --allow-net --allow-env cli.ts models
+ *
+ * The API key is read from the OPENAI_API_KEY environment variable
+ * (or the --key flag).
+ */
+import { DEFAULT_MODEL, OpenAI } from "./mod.ts";
+
+const USAGE = `openai <command> [options]
+
+Commands:
+  chat <prompt...>   complete a chat prompt (reads stdin if prompt is "-")
+  models             list available model ids
+
+Options:
+  --key=KEY          API key (default: OPENAI_API_KEY environment variable)
+  --model=MODEL      model id (default: ${DEFAULT_MODEL})
+  --system=TEXT      system instruction
+  --temperature=N    sampling temperature
+  --max-tokens=N     completion token limit
+  --no-stream        wait for the full response instead of streaming
+  --help             show this message`;
+
+interface ParsedArgs {
+  command?: string;
+  positional: string[];
+  flags: Record<string, string | boolean>;
+}
+
+/** Tiny flag parser: supports --flag, --flag=value, and positionals. */
+export const parseArgs = (args: string[]): ParsedArgs => {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  for (const arg of args) {
+    if (arg.startsWith("--")) {
+      const eq = arg.indexOf("=");
+      if (eq === -1) {
+        flags[arg.slice(2)] = true;
+      } else {
+        flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+      }
+    } else {
+      positional.push(arg);
+    }
+  }
+  const [command, ...rest] = positional;
+  return { command, positional: rest, flags };
+};
+
+const main = async () => {
+  const { command, positional, flags } = parseArgs(Deno.args);
+
+  if (flags.help || !command) {
+    console.log(USAGE);
+    Deno.exit(command ? 0 : 1);
+  }
+
+  const apiKey = typeof flags.key === "string"
+    ? flags.key
+    : Deno.env.get("OPENAI_API_KEY") ?? "";
+  if (!apiKey) {
+    console.error("error: no API key; set OPENAI_API_KEY or pass --key");
+    Deno.exit(1);
+  }
+
+  const client = new OpenAI({ apiKey });
+
+  switch (command) {
+    case "models": {
+      for (const { id } of await client.models()) {
+        console.log(id);
+      }
+      break;
+    }
+    case "chat": {
+      let prompt = positional.join(" ");
+      if (prompt === "-" || prompt === "") {
+        const chunks: Uint8Array[] = [];
+        for await (const chunk of Deno.stdin.readable) {
+          chunks.push(chunk);
+        }
+        prompt = new TextDecoder().decode(
+          new Uint8Array(await new Blob(chunks as BlobPart[]).arrayBuffer()),
+        ).trim();
+      }
+      if (!prompt) {
+        console.error("error: no prompt provided");
+        Deno.exit(1);
+      }
+      const options = {
+        model: typeof flags.model === "string" ? flags.model : undefined,
+        system: typeof flags.system === "string" ? flags.system : undefined,
+        temperature: typeof flags.temperature === "string"
+          ? Number(flags.temperature)
+          : undefined,
+        maxTokens: typeof flags["max-tokens"] === "string"
+          ? Number(flags["max-tokens"])
+          : undefined,
+      };
+      if (flags["no-stream"]) {
+        const completion = await client.chat(prompt, options);
+        console.log(completion.choices[0]?.message?.content ?? "");
+      } else {
+        const encoder = new TextEncoder();
+        for await (const delta of client.chatStream(prompt, options)) {
+          await Deno.stdout.write(encoder.encode(delta));
+        }
+        await Deno.stdout.write(encoder.encode("\n"));
+      }
+      break;
+    }
+    default: {
+      console.error(`error: unknown command "${command}"\n\n${USAGE}`);
+      Deno.exit(1);
+    }
+  }
+};
+
+if (import.meta.main) {
+  await main();
+}

--- a/ts/openai/0.1.0/deno.json
+++ b/ts/openai/0.1.0/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@johnhenry/openai",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./mod.ts",
+    "./cli": "./cli.ts"
+  },
+  "tasks": {
+    "check": "deno check mod.ts cli.ts mod.test.ts",
+    "test": "deno test"
+  }
+}

--- a/ts/openai/0.1.0/mod.test.ts
+++ b/ts/openai/0.1.0/mod.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for the openai module. No network access: the client is
+ * exercised with an injected fake fetch, and stream parsing is fed
+ * in-memory ReadableStreams.
+ */
+import {
+  buildChatBody,
+  buildRequest,
+  chatStreamText,
+  completionText,
+  DEFAULT_BASE_URL,
+  DEFAULT_MODEL,
+  OpenAI,
+  OpenAIError,
+  sseData,
+  toMessages,
+} from "./mod.ts";
+import { parseArgs } from "./cli.ts";
+
+const assert = (condition: boolean, message: string) => {
+  if (!condition) throw new Error(`assertion failed: ${message}`);
+};
+const assertEquals = (actual: unknown, expected: unknown) => {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) throw new Error(`expected ${e}, got ${a}`);
+};
+
+const bytes = (...parts: string[]): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) controller.enqueue(encoder.encode(part));
+      controller.close();
+    },
+  });
+};
+
+Deno.test("toMessages wraps a string prompt as a user message", () => {
+  assertEquals(toMessages("hello"), [{ role: "user", content: "hello" }]);
+});
+
+Deno.test("toMessages prepends a system instruction", () => {
+  assertEquals(toMessages("hi", "be brief"), [
+    { role: "system", content: "be brief" },
+    { role: "user", content: "hi" },
+  ]);
+});
+
+Deno.test("toMessages copies an existing messages array", () => {
+  const input = [{ role: "user" as const, content: "x" }];
+  const output = toMessages(input);
+  assertEquals(output, input);
+  assert(output !== input, "should be a copy");
+});
+
+Deno.test("buildChatBody maps options to API parameter names", () => {
+  const body = buildChatBody("hi", {
+    model: "gpt-4o",
+    maxTokens: 32,
+    temperature: 0.5,
+    topP: 0.9,
+    stop: ["\n"],
+    presencePenalty: 0.1,
+    frequencyPenalty: 0.2,
+  });
+  assertEquals(body.model, "gpt-4o");
+  assertEquals(body.max_completion_tokens, 32);
+  assertEquals(body.temperature, 0.5);
+  assertEquals(body.top_p, 0.9);
+  assertEquals(body.stop, ["\n"]);
+  assertEquals(body.presence_penalty, 0.1);
+  assertEquals(body.frequency_penalty, 0.2);
+  assert(!("stream" in body), "stream flag should be absent by default");
+});
+
+Deno.test("buildChatBody defaults model and omits unset options", () => {
+  const body = buildChatBody("hi");
+  assertEquals(body.model, DEFAULT_MODEL);
+  assertEquals(Object.keys(body).sort(), ["messages", "model"]);
+});
+
+Deno.test("buildChatBody sets stream when requested", () => {
+  assertEquals(buildChatBody("hi", {}, true).stream, true);
+});
+
+Deno.test("buildRequest builds an authorized POST with JSON body", async () => {
+  const request = buildRequest("/chat/completions", "sk-test", { a: 1 });
+  assertEquals(request.url, `${DEFAULT_BASE_URL}/chat/completions`);
+  assertEquals(request.method, "POST");
+  assertEquals(request.headers.get("authorization"), "Bearer sk-test");
+  assertEquals(request.headers.get("content-type"), "application/json");
+  assertEquals(await request.json(), { a: 1 });
+});
+
+Deno.test("buildRequest builds a GET when there is no body", () => {
+  const request = buildRequest("/models", "sk-test");
+  assertEquals(request.method, "GET");
+  assertEquals(request.url, `${DEFAULT_BASE_URL}/models`);
+});
+
+Deno.test("buildRequest normalizes a trailing slash in baseUrl", () => {
+  const request = buildRequest("/models", "k", undefined, "http://x/v1/");
+  assertEquals(request.url, "http://x/v1/models");
+});
+
+Deno.test("completionText extracts first-choice content", () => {
+  const completion = {
+    id: "c",
+    object: "chat.completion",
+    created: 0,
+    model: "m",
+    choices: [{
+      index: 0,
+      message: { role: "assistant", content: "hello there" },
+      finish_reason: "stop",
+    }],
+  };
+  assertEquals(completionText(completion), "hello there");
+});
+
+Deno.test("sseData yields data payloads and stops at [DONE]", async () => {
+  const stream = bytes(
+    'data: {"a":1}\n\n',
+    "data: ",
+    '{"b":2}\n\ndata: [DONE]\n\ndata: {"never":true}\n\n',
+  );
+  const seen: string[] = [];
+  for await (const data of sseData(stream)) seen.push(data);
+  assertEquals(seen, ['{"a":1}', '{"b":2}']);
+});
+
+Deno.test("chatStreamText yields content deltas only", async () => {
+  const chunk = (content: string | null) =>
+    `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`;
+  const stream = bytes(
+    chunk("Hel"),
+    chunk("lo"),
+    `data: ${JSON.stringify({ choices: [{ delta: {} }] })}\n\n`,
+    "data: [DONE]\n\n",
+  );
+  const parts: string[] = [];
+  for await (const delta of chatStreamText(stream)) parts.push(delta);
+  assertEquals(parts.join(""), "Hello");
+});
+
+Deno.test("OpenAI.chat sends the right request via injected fetch", async () => {
+  let captured: Request | undefined;
+  const fake = ((input: Request | URL | string) => {
+    captured = input as Request;
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          id: "c",
+          object: "chat.completion",
+          created: 0,
+          model: DEFAULT_MODEL,
+          choices: [{
+            index: 0,
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          }],
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      ),
+    );
+  }) as typeof fetch;
+
+  const client = new OpenAI({ apiKey: "sk-test", fetch: fake });
+  const completion = await client.chat("ping", { system: "pong" });
+
+  assert(captured !== undefined, "fetch should be called");
+  assertEquals(captured!.url, `${DEFAULT_BASE_URL}/chat/completions`);
+  assertEquals(captured!.headers.get("authorization"), "Bearer sk-test");
+  const body = await captured!.json();
+  assertEquals(body.messages, [
+    { role: "system", content: "pong" },
+    { role: "user", content: "ping" },
+  ]);
+  assertEquals(completionText(completion), "ok");
+});
+
+Deno.test("OpenAI.models unwraps the data array", async () => {
+  const fake = (() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({ data: [{ id: "gpt-4o", object: "model" }] }),
+      ),
+    )) as typeof fetch;
+  const client = new OpenAI({ apiKey: "k", fetch: fake });
+  assertEquals(await client.models(), [{ id: "gpt-4o", object: "model" }]);
+});
+
+Deno.test("OpenAI throws OpenAIError on non-2xx responses", async () => {
+  const fake = (() =>
+    Promise.resolve(
+      new Response("nope", { status: 401 }),
+    )) as typeof fetch;
+  const client = new OpenAI({ apiKey: "bad", fetch: fake });
+  let thrown: unknown;
+  try {
+    await client.chat("hi");
+  } catch (error) {
+    thrown = error;
+  }
+  assert(thrown instanceof OpenAIError, "should throw OpenAIError");
+  assertEquals((thrown as OpenAIError).status, 401);
+});
+
+Deno.test("OpenAI constructor requires an apiKey", () => {
+  let thrown = false;
+  try {
+    new OpenAI({ apiKey: "" });
+  } catch {
+    thrown = true;
+  }
+  assert(thrown, "empty apiKey should throw");
+});
+
+Deno.test("cli parseArgs handles commands, flags, and values", () => {
+  const parsed = parseArgs([
+    "chat",
+    "say",
+    "hello",
+    "--model=gpt-4o",
+    "--no-stream",
+  ]);
+  assertEquals(parsed.command, "chat");
+  assertEquals(parsed.positional, ["say", "hello"]);
+  assertEquals(parsed.flags, { model: "gpt-4o", "no-stream": true });
+});

--- a/ts/openai/0.1.0/mod.ts
+++ b/ts/openai/0.1.0/mod.ts
@@ -1,0 +1,260 @@
+/**
+ * openai — a minimal, dependency-free OpenAI API client for Deno.
+ *
+ * Targets the current OpenAI REST API:
+ *   - POST /v1/chat/completions (messages array, optional SSE streaming)
+ *   - POST /v1/responses (the newer Responses API)
+ *   - GET  /v1/models
+ *
+ * Everything is plain `fetch`; the fetch implementation is injectable so the
+ * request-building and response-parsing logic is testable without a network.
+ */
+
+export const DEFAULT_BASE_URL = "https://api.openai.com/v1";
+export const DEFAULT_MODEL = "gpt-4o-mini";
+
+export type Role = "system" | "developer" | "user" | "assistant" | "tool";
+
+export interface ChatMessage {
+  role: Role;
+  content: string;
+}
+
+export interface ChatOptions {
+  /** Model id, e.g. "gpt-4o-mini". Defaults to {@linkcode DEFAULT_MODEL}. */
+  model?: string;
+  /** Upper bound on generated tokens (sent as `max_completion_tokens`). */
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  /** Number of choices to generate. */
+  n?: number;
+  /** Up to 4 stop sequences. */
+  stop?: string | string[];
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  /** Optional system/developer instruction prepended to the messages. */
+  system?: string;
+}
+
+export interface ChatChoice {
+  index: number;
+  message: { role: string; content: string | null };
+  finish_reason: string | null;
+}
+
+export interface ChatCompletion {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: ChatChoice[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export interface Model {
+  id: string;
+  object: string;
+  created?: number;
+  owned_by?: string;
+}
+
+export interface ClientOptions {
+  /** OpenAI API key (typically from the OPENAI_API_KEY environment variable). */
+  apiKey: string;
+  /** Override the API root; defaults to {@linkcode DEFAULT_BASE_URL}. */
+  baseUrl?: string;
+  /** Injectable fetch implementation (used by tests; defaults to global fetch). */
+  fetch?: typeof fetch;
+}
+
+/** Error thrown for non-2xx API responses. */
+export class OpenAIError extends Error {
+  status: number;
+  body: string;
+  constructor(status: number, body: string) {
+    super(`OpenAI API error ${status}: ${body}`);
+    this.name = "OpenAIError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/** Normalize a prompt string (or ready-made message array) into messages. */
+export const toMessages = (
+  input: string | ChatMessage[],
+  system?: string,
+): ChatMessage[] => {
+  const messages: ChatMessage[] = typeof input === "string"
+    ? [{ role: "user", content: input }]
+    : [...input];
+  if (system) {
+    messages.unshift({ role: "system", content: system });
+  }
+  return messages;
+};
+
+/** Build the JSON body for POST /v1/chat/completions. */
+export const buildChatBody = (
+  input: string | ChatMessage[],
+  options: ChatOptions = {},
+  stream = false,
+): Record<string, unknown> => {
+  const body: Record<string, unknown> = {
+    model: options.model ?? DEFAULT_MODEL,
+    messages: toMessages(input, options.system),
+  };
+  if (options.maxTokens !== undefined) {
+    body.max_completion_tokens = options.maxTokens;
+  }
+  if (options.temperature !== undefined) body.temperature = options.temperature;
+  if (options.topP !== undefined) body.top_p = options.topP;
+  if (options.n !== undefined) body.n = options.n;
+  if (options.stop !== undefined) body.stop = options.stop;
+  if (options.presencePenalty !== undefined) {
+    body.presence_penalty = options.presencePenalty;
+  }
+  if (options.frequencyPenalty !== undefined) {
+    body.frequency_penalty = options.frequencyPenalty;
+  }
+  if (stream) body.stream = true;
+  return body;
+};
+
+/** Build a fetch Request for an API call. */
+export const buildRequest = (
+  path: string,
+  apiKey: string,
+  body?: unknown,
+  baseUrl: string = DEFAULT_BASE_URL,
+): Request =>
+  new Request(`${baseUrl.replace(/\/+$/, "")}${path}`, {
+    method: body === undefined ? "GET" : "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+/** Extract the text of the first choice of a chat completion. */
+export const completionText = (completion: ChatCompletion): string =>
+  completion.choices?.[0]?.message?.content ?? "";
+
+/**
+ * Parse a server-sent-events byte stream, yielding each `data:` payload
+ * (as a string) until the stream ends or an "[DONE]" sentinel is seen.
+ */
+export async function* sseData(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<string> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const chunk of stream) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let index: number;
+    while ((index = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, index).replace(/\r$/, "");
+      buffer = buffer.slice(index + 1);
+      if (!line.startsWith("data:")) continue;
+      const data = line.slice(5).trim();
+      if (data === "[DONE]") return;
+      if (data) yield data;
+    }
+  }
+}
+
+/**
+ * Turn a chat-completions SSE byte stream into a stream of content deltas
+ * (the incremental text of the first choice).
+ */
+export async function* chatStreamText(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<string> {
+  for await (const data of sseData(stream)) {
+    const parsed = JSON.parse(data) as {
+      choices?: { delta?: { content?: string | null } }[];
+    };
+    const delta = parsed.choices?.[0]?.delta?.content;
+    if (delta) yield delta;
+  }
+}
+
+/** Minimal OpenAI API client. */
+export class OpenAI {
+  #apiKey: string;
+  #baseUrl: string;
+  #fetch: typeof fetch;
+
+  constructor({ apiKey, baseUrl = DEFAULT_BASE_URL, fetch: fetchImpl }: ClientOptions) {
+    if (!apiKey) {
+      throw new Error("apiKey is required (set OPENAI_API_KEY)");
+    }
+    this.#apiKey = apiKey;
+    this.#baseUrl = baseUrl;
+    this.#fetch = fetchImpl ?? fetch;
+  }
+
+  async #call(path: string, body?: unknown): Promise<Response> {
+    const response = await this.#fetch(
+      buildRequest(path, this.#apiKey, body, this.#baseUrl),
+    );
+    if (!response.ok) {
+      throw new OpenAIError(response.status, await response.text());
+    }
+    return response;
+  }
+
+  /** Create a chat completion. Accepts a prompt string or a messages array. */
+  async chat(
+    input: string | ChatMessage[],
+    options: ChatOptions = {},
+  ): Promise<ChatCompletion> {
+    const response = await this.#call(
+      "/chat/completions",
+      buildChatBody(input, options),
+    );
+    return await response.json() as ChatCompletion;
+  }
+
+  /** Create a streaming chat completion; yields text deltas as they arrive. */
+  async *chatStream(
+    input: string | ChatMessage[],
+    options: ChatOptions = {},
+  ): AsyncGenerator<string> {
+    const response = await this.#call(
+      "/chat/completions",
+      buildChatBody(input, options, true),
+    );
+    if (!response.body) {
+      throw new Error("response has no body");
+    }
+    yield* chatStreamText(response.body);
+  }
+
+  /** Call the Responses API (POST /v1/responses); returns the raw response object. */
+  async respond(
+    input: string,
+    options: { model?: string; instructions?: string } = {},
+  ): Promise<Record<string, unknown>> {
+    const response = await this.#call("/responses", {
+      model: options.model ?? DEFAULT_MODEL,
+      input,
+      ...(options.instructions ? { instructions: options.instructions } : {}),
+    });
+    return await response.json() as Record<string, unknown>;
+  }
+
+  /** List available models (GET /v1/models). */
+  async models(): Promise<Model[]> {
+    const response = await this.#call("/models");
+    const { data } = await response.json() as { data: Model[] };
+    return data;
+  }
+}
+
+export default OpenAI;

--- a/ts/openai/0.1.0/readme.md
+++ b/ts/openai/0.1.0/readme.md
@@ -1,0 +1,75 @@
+# openai
+
+A minimal, dependency-free [OpenAI](https://openai.com/) API client and
+command line tool for [Deno](https://deno.com). It targets the current
+OpenAI REST API: chat completions (`POST /v1/chat/completions`, with
+optional streaming), the Responses API (`POST /v1/responses`), and model
+listing (`GET /v1/models`).
+
+> **Note:** version [0.0.0](../0.0.0/readme.md) of this module targeted the
+> retired engines/completions API (`/v1/engines/*/completions`) and is
+> deprecated; it no longer works against the live OpenAI API. Use 0.1.0.
+
+## usage
+
+### as a module
+
+```javascript
+import OpenAI, {
+  completionText,
+} from "https://johnhenry.github.io/lib/ts/openai/0.1.0/mod.ts";
+
+const client = new OpenAI({ apiKey: Deno.env.get("OPENAI_API_KEY") });
+
+// Chat completion
+const completion = await client.chat("Say hello in one word.");
+console.log(completionText(completion));
+
+// Streaming
+for await (const delta of client.chatStream("Tell me a short story.")) {
+  Deno.stdout.write(new TextEncoder().encode(delta));
+}
+
+// Responses API
+const response = await client.respond("Say hello in one word.");
+
+// List models
+const models = await client.models();
+```
+
+### as a command line tool
+
+The API key is read from the `OPENAI_API_KEY` environment variable
+(or the `--key` flag).
+
+```sh
+deno run --allow-net --allow-env \
+  https://johnhenry.github.io/lib/ts/openai/0.1.0/cli.ts \
+  chat "Say hello in one word."
+```
+
+```sh
+deno run --allow-net --allow-env \
+  https://johnhenry.github.io/lib/ts/openai/0.1.0/cli.ts \
+  models
+```
+
+Or install it:
+
+```sh
+deno install --global --name=openai --allow-net --allow-env \
+  https://johnhenry.github.io/lib/ts/openai/0.1.0/cli.ts
+openai chat "Say hello in one word." --model=gpt-4o-mini
+```
+
+Flags for `chat`: `--model`, `--system`, `--temperature`, `--max-tokens`,
+`--no-stream`, `--key`. Pass `-` (or pipe with no prompt) to read the
+prompt from stdin.
+
+## testing
+
+Tests are pure unit tests (no network, no environment variables needed):
+
+```sh
+deno task test
+```

--- a/ts/serverless-workers/0.1.0/deno.json
+++ b/ts/serverless-workers/0.1.0/deno.json
@@ -1,0 +1,11 @@
+{
+  "name": "@johnhenry/serverless-workers",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "tasks": {
+    "check": "deno check mod.ts mod.test.ts",
+    "test": "deno test"
+  }
+}

--- a/ts/serverless-workers/0.1.0/mod.test.ts
+++ b/ts/serverless-workers/0.1.0/mod.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for serverless-workers. Routing is exercised through
+ * `server.handler` directly — no server is started and no network
+ * access is needed.
+ */
+import Server from "./mod.ts";
+
+const assert = (condition: boolean, message: string) => {
+  if (!condition) throw new Error(`assertion failed: ${message}`);
+};
+const assertEquals = (actual: unknown, expected: unknown) => {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) throw new Error(`expected ${e}, got ${a}`);
+};
+
+const text = async (response: Response | Promise<Response>) =>
+  await (await response).text();
+
+Deno.test("routes requests to a mounted handler by path prefix", async () => {
+  const server = new Server();
+  await server.mount(() => new Response("random"), { path: "/random" });
+
+  const hit = await server.handler(new Request("http://localhost/random"));
+  assertEquals(hit.status, 200);
+  assertEquals(await hit.text(), "random");
+
+  const sub = await server.handler(
+    new Request("http://localhost/random/nested"),
+  );
+  assertEquals(await sub.text(), "random");
+});
+
+Deno.test("longest matching prefix wins", async () => {
+  const server = new Server();
+  await server.mount(() => new Response("root"), { path: "/" });
+  await server.mount(() => new Response("api"), { path: "/api" });
+  await server.mount(() => new Response("api-v2"), { path: "/api/v2" });
+
+  assertEquals(await text(server.handler(new Request("http://x/"))), "root");
+  assertEquals(await text(server.handler(new Request("http://x/api"))), "api");
+  assertEquals(
+    await text(server.handler(new Request("http://x/api/v2/users"))),
+    "api-v2",
+  );
+  assertEquals(
+    await text(server.handler(new Request("http://x/other"))),
+    "root",
+  );
+});
+
+Deno.test("does not match partial path segments", async () => {
+  const server = new Server();
+  await server.mount(() => new Response("api"), { path: "/api" });
+  const miss = await server.handler(new Request("http://x/apiary"));
+  assertEquals(miss.status, 404);
+});
+
+Deno.test("unmatched requests get a 404 by default", async () => {
+  const server = new Server();
+  const response = await server.handler(new Request("http://x/nothing"));
+  assertEquals(response.status, 404);
+});
+
+Deno.test("a custom notFound handler is used for misses", async () => {
+  const server = new Server({
+    notFound: () => new Response("teapot", { status: 418 }),
+  });
+  const response = await server.handler(new Request("http://x/none"));
+  assertEquals(response.status, 418);
+  assertEquals(await response.text(), "teapot");
+});
+
+Deno.test("mount paths are normalized", async () => {
+  const server = new Server();
+  await server.mount(() => new Response("ok"), { path: "random/" });
+  assertEquals(server.mounts[0].path, "/random");
+  const response = await server.handler(new Request("http://x/random"));
+  assertEquals(await response.text(), "ok");
+});
+
+Deno.test("unmount removes a mount by id", async () => {
+  const server = new Server();
+  const id = await server.mount(() => new Response("gone"), {
+    path: "/gone",
+  });
+  assertEquals(server.mounts.length, 1);
+  assert(server.unmount(id), "unmount should report success");
+  assertEquals(server.mounts.length, 0);
+  assert(!server.unmount(id), "second unmount should report failure");
+  const response = await server.handler(new Request("http://x/gone"));
+  assertEquals(response.status, 404);
+});
+
+Deno.test("mount accepts a module specifier with a default export", async () => {
+  const server = new Server();
+  const specifier = "data:application/typescript," + encodeURIComponent(
+    "export default () => new Response('from module');",
+  );
+  await server.mount(specifier, { path: "/mod" });
+  const response = await server.handler(new Request("http://x/mod"));
+  assertEquals(await response.text(), "from module");
+});
+
+Deno.test("mount rejects modules without a default function export", async () => {
+  const server = new Server();
+  const specifier = "data:application/typescript," +
+    encodeURIComponent("export const nothing = 1;");
+  let thrown: unknown;
+  try {
+    await server.mount(specifier);
+  } catch (error) {
+    thrown = error;
+  }
+  assert(thrown instanceof TypeError, "should throw TypeError");
+});
+
+Deno.test("port and uptime reflect stopped state", () => {
+  const server = new Server();
+  assertEquals(server.port, undefined);
+  assertEquals(server.uptime, 0);
+});

--- a/ts/serverless-workers/0.1.0/mod.ts
+++ b/ts/serverless-workers/0.1.0/mod.ts
@@ -1,0 +1,149 @@
+/**
+ * serverless-workers — mount fetch-style handlers (workers) at URL paths
+ * on a small Deno HTTP server.
+ *
+ * Version 0.0.0 was a design sketch (see ../0.0.0/index.md) for a "worker"
+ * tool that mounts fetch/express-style modules on managed servers. 0.1.0
+ * implements the core of that idea as a working module: a {@linkcode Server}
+ * that routes requests to mounted handlers by longest path prefix, served
+ * with modern `Deno.serve`.
+ */
+
+/** A web-standard fetch handler, as used by service/Cloudflare workers. */
+export type FetchHandler = (
+  request: Request,
+) => Response | Promise<Response>;
+
+export interface MountOptions {
+  /** URL path prefix to mount at (default "/"). */
+  path?: string;
+}
+
+export interface Mount {
+  id: string;
+  path: string;
+  handler: FetchHandler;
+  mountedAt: number;
+}
+
+export interface ServerOptions {
+  /** Handler used when no mount matches (default: 404 response). */
+  notFound?: FetchHandler;
+}
+
+const normalizePath = (path: string): string => {
+  let normalized = path.startsWith("/") ? path : `/${path}`;
+  if (normalized.length > 1) normalized = normalized.replace(/\/+$/, "");
+  return normalized;
+};
+
+const defaultNotFound: FetchHandler = () =>
+  new Response("Not Found", { status: 404 });
+
+/** A server that routes requests to mounted worker handlers. */
+export class Server {
+  #mounts = new Map<string, Mount>();
+  #nextId = 0;
+  #notFound: FetchHandler;
+  #server?: Deno.HttpServer<Deno.NetAddr>;
+  #port?: number;
+  #startedAt?: number;
+
+  constructor({ notFound = defaultNotFound }: ServerOptions = {}) {
+    this.#notFound = notFound;
+  }
+
+  /**
+   * Mount a fetch handler (or a module specifier whose default export is a
+   * fetch handler) at a path prefix. Returns the mount id.
+   */
+  async mount(
+    worker: FetchHandler | string | URL,
+    { path = "/" }: MountOptions = {},
+  ): Promise<string> {
+    let handler: FetchHandler;
+    if (typeof worker === "function") {
+      handler = worker;
+    } else {
+      const module = await import(worker.toString());
+      if (typeof module.default !== "function") {
+        throw new TypeError(
+          `module "${worker}" has no default fetch-handler export`,
+        );
+      }
+      handler = module.default as FetchHandler;
+    }
+    const id = `${this.#nextId++}`;
+    this.#mounts.set(id, {
+      id,
+      path: normalizePath(path),
+      handler,
+      mountedAt: Date.now(),
+    });
+    return id;
+  }
+
+  /** Remove a mount by id; returns whether it existed. */
+  unmount(id: string): boolean {
+    return this.#mounts.delete(id);
+  }
+
+  /** Current mounts, in mount order. */
+  get mounts(): Mount[] {
+    return [...this.#mounts.values()];
+  }
+
+  /** Port the server is listening on (undefined when stopped). */
+  get port(): number | undefined {
+    return this.#port;
+  }
+
+  /** Milliseconds since start (0 when stopped). */
+  get uptime(): number {
+    return this.#startedAt === undefined ? 0 : Date.now() - this.#startedAt;
+  }
+
+  /**
+   * Route a request to the mounted handler with the longest matching path
+   * prefix. Usable directly (e.g. in tests, or as a Deno.serve handler)
+   * without starting the built-in server.
+   */
+  handler: FetchHandler = (request) => {
+    const { pathname } = new URL(request.url);
+    let best: Mount | undefined;
+    for (const mount of this.#mounts.values()) {
+      const matches = mount.path === "/" ||
+        pathname === mount.path ||
+        pathname.startsWith(`${mount.path}/`);
+      if (matches && (best === undefined || mount.path.length > best.path.length)) {
+        best = mount;
+      }
+    }
+    return (best?.handler ?? this.#notFound)(request);
+  };
+
+  /** Start serving with Deno.serve. */
+  start(
+    port = 8080,
+    options: { hostname?: string; signal?: AbortSignal } = {},
+  ): Deno.HttpServer<Deno.NetAddr> {
+    if (this.#server) {
+      throw new Error("server is already running");
+    }
+    this.#server = Deno.serve({ port, ...options }, this.handler);
+    this.#port = this.#server.addr.port;
+    this.#startedAt = Date.now();
+    return this.#server;
+  }
+
+  /** Stop the server (no-op when not running). */
+  async stop(): Promise<void> {
+    if (!this.#server) return;
+    await this.#server.shutdown();
+    this.#server = undefined;
+    this.#port = undefined;
+    this.#startedAt = undefined;
+  }
+}
+
+export default Server;

--- a/ts/serverless-workers/0.1.0/readme.md
+++ b/ts/serverless-workers/0.1.0/readme.md
@@ -1,0 +1,51 @@
+# serverless-workers
+
+Mount fetch-style handlers ("workers") at URL paths on a small
+[Deno](https://deno.com) HTTP server. Requests are routed to the mounted
+handler with the longest matching path prefix and served with `Deno.serve`.
+
+Version [0.0.0](../0.0.0/index.md) was a design sketch for a worker/daemon
+CLI that mounts fetch and express-style modules on managed servers; 0.1.0
+implements the core of that idea — a `Server` with `mount`/`unmount`,
+prefix routing, and `start`/`stop` — as a working module.
+
+## usage
+
+```javascript
+import Server from "https://johnhenry.github.io/lib/ts/serverless-workers/0.1.0/mod.ts";
+
+const server = new Server();
+
+// Mount a fetch handler at a path prefix.
+await server.mount((request) => new Response("random"), { path: "/random" });
+
+// Or mount a module whose default export is a fetch handler.
+await server.mount("./random.fetch.mjs", { path: "/random1" });
+
+server.start(8080);
+
+server.mounts; // [{ id, path, handler, mountedAt }, ...]
+server.port; // 8080
+server.uptime; // ms since start
+
+await server.stop();
+```
+
+Run a file using it:
+
+```sh
+deno run --allow-net my-server.ts
+```
+
+Unmatched requests get a `404` (customizable via
+`new Server({ notFound })`). `server.handler` is a plain
+`(request) => Response` function, so it can also be passed straight to
+`Deno.serve` or called directly in tests.
+
+## testing
+
+Tests call `server.handler` directly — no network access needed:
+
+```sh
+deno task test
+```


### PR DESCRIPTION
## What
New 0.1.0 version dirs beside the frozen 0.0.0 originals (additions only — verified):

- **ts/openai/0.1.0/** — zero-dependency client for the *current* OpenAI API over plain fetch: `chat()` (chat completions), `chatStream()` (SSE), `respond()` (Responses API), `models()`, plus a small CLI (`deno run cli.ts chat`). Injectable fetch makes everything testable offline. The 0.0.0 readme-documented deprecation: it targeted the retired engines/completions API.
- **ts/initiate-http/0.1.0/** — service-worker-style global `fetch` events rebuilt on `Deno.serve` (the old `Deno.serveHttp` was removed).
- **ts/serverless-workers/0.1.0/** — 0.0.0 was only a design sketch; this implements it: `Server` with `mount()`/`unmount()`, segment-aware longest-prefix routing, `Deno.serve` lifecycle.

## CI
New `deno` job in test.yaml (setup-deno@v2): `deno check` + `deno test` scoped strictly to the 0.1.0 dirs — old dirs are frozen published bytes and stay unchecked.

## Verification
`deno check` clean on Deno 2.9; **32 tests pass** (no network/env needed); URL contract green (977 paths intact).

Stacked on #9. Final PR in the lib modernization series.