### PR TITLE
pop-quiz 1.0.1: point at johnhenry/pop-quiz as canonical source

### DIFF
--- a/contract/generated-files.txt
+++ b/contract/generated-files.txt
@@ -201,6 +201,7 @@ js/polyfill-window.component/0.0.0/index.html
 js/polyfill-window.component/index.html
 js/pop-quiz/0.0.5/index.html
 js/pop-quiz/1.0.0/index.html
+js/pop-quiz/1.0.1/index.html
 js/pop-quiz/index.html
 js/prototypeChainWalker/index.html
 js/qbit/index.html

--- a/js/pop-quiz/1.0.1/TAPRunner.mjs
+++ b/js/pop-quiz/1.0.1/TAPRunner.mjs
@@ -106,12 +106,17 @@ export const print = async function (
   if (logVersion) {
     log(`TAP version ${TAP_VERSION}`);
   }
+  let failCount = 0;
+  const captureCounts = (tests, pass, fail) => {
+    failCount = fail;
+    return TAPResultCounts(tests, pass, fail);
+  };
   for await (const output of run(
     test,
     title,
     TAPResultPass,
     TAPResultFail,
-    TAPResultCounts,
+    captureCounts,
     TAPResultRange
   )) {
     if (output instanceof TestError) {
@@ -120,4 +125,12 @@ export const print = async function (
       log(output);
     }
   }
+  // Without this, a failing TAP run still exits 0 — CI (or any script
+  // checking the exit code) would never notice a failure. `process` isn't
+  // guaranteed to exist here (this module also runs in the browser), so
+  // this only takes effect where it's available.
+  if (failCount > 0 && typeof process !== "undefined") {
+    process.exitCode = 1;
+  }
+  return failCount === 0;
 };

--- a/js/pop-quiz/1.0.1/TAPRunner.mjs
+++ b/js/pop-quiz/1.0.1/TAPRunner.mjs
@@ -1,0 +1,123 @@
+const TAP_VERSION = 13;
+import TestError from "./testerror.mjs";
+
+export const TAPResultRange = function (num) {
+  return `1..${num}`;
+};
+
+export const TAPResultTitle = function (title) {
+  return `# ${title}`;
+};
+export const TAPResultFail = function (output, index) {
+  const { message } = output;
+  const result = [];
+  result.push(`not ok ${index} - ${message}`);
+  result.push(`  ---`);
+  for (const [key, value] of output) {
+    result.push(`    ${key}: ${value}`);
+  }
+  result.push(`  ...`);
+  return result.join("\n");
+};
+
+export const TAPResultPass = function (output, index) {
+  return `ok ${index} - ${output}`;
+};
+
+export const TAPResultCounts = function (tests, pass, fail) {
+  const result = [];
+  result.push(`# tests ${tests}`);
+  result.push(`# pass  ${pass}`);
+  result.push(`# fail  ${fail}`);
+  return result.join("\n");
+};
+
+const empty = () => {};
+const identity = (x) => x;
+export const run = async function* (
+  test,
+  title = "",
+  resultPass = identity,
+  resultFail = identity,
+  resultCounts = empty,
+  resultRange = empty
+) {
+  if (title) {
+    yield title;
+  }
+  let index = 1;
+  let planCalled = false;
+  let indexPrinted = false;
+  let num;
+  let started;
+  const plan = (number) => {
+    if (planCalled) {
+      throw new Error("do not call plan more than once");
+    }
+    planCalled = true;
+    num = number;
+  };
+  let tests = 0;
+  let pass = 0;
+  let fail = 0;
+  for await (const output of test(plan)) {
+    if (planCalled && !started) {
+      let range;
+      if (num === undefined) {
+        range = resultRange(index - 1);
+      } else {
+        range = resultRange(num);
+      }
+      if (range) {
+        yield range;
+      }
+      indexPrinted = true;
+    }
+    if (output instanceof TestError) {
+      yield resultFail(output, index);
+      fail++;
+    } else {
+      yield resultPass(output, index);
+      pass++;
+    }
+    index++;
+    tests++;
+    started = true;
+  }
+  if (!indexPrinted) {
+    const range = resultRange(index - 1);
+    if (range) {
+      yield range;
+    }
+  }
+  const counts = resultCounts(tests, pass, fail);
+  if (counts) {
+    yield counts;
+  }
+};
+
+export const print = async function (
+  test,
+  title,
+  log = console.log,
+  logError = console.error,
+  logVersion = true
+) {
+  if (logVersion) {
+    log(`TAP version ${TAP_VERSION}`);
+  }
+  for await (const output of run(
+    test,
+    title,
+    TAPResultPass,
+    TAPResultFail,
+    TAPResultCounts,
+    TAPResultRange
+  )) {
+    if (output instanceof TestError) {
+      logError(output);
+    } else {
+      log(output);
+    }
+  }
+};

--- a/js/pop-quiz/1.0.1/assertions/deepdeepequal.mjs
+++ b/js/pop-quiz/1.0.1/assertions/deepdeepequal.mjs
@@ -1,0 +1,108 @@
+import TestError from "../testerror.mjs";
+
+// Like deepequal, but also handles cases deepequal silently gets wrong:
+//   - Map/Set have no own enumerable string keys, so deepequal's
+//     Object.keys() comparison sees two different-content Maps (or Sets)
+//     as "equal" (both compare as 0 keys === 0 keys).
+//   - Circular references: deepequal recurses forever (stack overflow).
+//     `seen` tracks (a, b) pairs already being compared on the current
+//     path, so a cycle that lines up on both sides is treated as equal.
+const deepDeepEqual = (a, b, seen) => {
+  if (a === b) return true;
+  if (a && b && typeof a === "object" && typeof b === "object") {
+    if (a.constructor !== b.constructor) return false;
+
+    let bSeen = seen.get(a);
+    if (bSeen) {
+      if (bSeen.has(b)) return true;
+    } else {
+      bSeen = new Set();
+      seen.set(a, bSeen);
+    }
+    bSeen.add(b);
+
+    if (Array.isArray(a)) {
+      if (a.length !== b.length) return false;
+      for (let i = a.length; i-- !== 0; ) {
+        if (!deepDeepEqual(a[i], b[i], seen)) return false;
+      }
+      return true;
+    }
+
+    if (a instanceof Map) {
+      if (a.size !== b.size) return false;
+      for (const [key, value] of a) {
+        if (!b.has(key)) return false;
+        if (!deepDeepEqual(value, b.get(key), seen)) return false;
+      }
+      return true;
+    }
+
+    if (a instanceof Set) {
+      if (a.size !== b.size) return false;
+      for (const value of a) {
+        let found = false;
+        for (const candidate of b) {
+          if (deepDeepEqual(value, candidate, seen)) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) return false;
+      }
+      return true;
+    }
+
+    if (a.constructor === RegExp) {
+      return a.source === b.source && a.flags === b.flags;
+    }
+    if (a.valueOf !== Object.prototype.valueOf) {
+      return a.valueOf() === b.valueOf();
+    }
+    if (a.toString !== Object.prototype.toString) {
+      return a.toString() === b.toString();
+    }
+
+    const keys = Object.keys(a);
+    if (keys.length !== Object.keys(b).length) return false;
+    for (const key of keys) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+    }
+    for (const key of keys) {
+      if (!deepDeepEqual(a[key], b[key], seen)) return false;
+    }
+    return true;
+  }
+  return a !== a && b !== b;
+};
+
+const safeStringify = (value) => {
+  try {
+    return JSON.stringify(value, (_key, v) =>
+      v instanceof Map
+        ? { __map__: [...v.entries()] }
+        : v instanceof Set
+          ? { __set__: [...v.values()] }
+          : v
+    );
+  } catch {
+    return String(value);
+  }
+};
+
+export const DefaultMessage = "should be deeply-deeply equal";
+export default (
+  actual,
+  expected,
+  message = DefaultMessage,
+  operator = "deepdeepequal"
+) => {
+  if (deepDeepEqual(actual, expected, new Map())) {
+    return message;
+  }
+  return new TestError(message, {
+    actual: safeStringify(actual),
+    expected: safeStringify(expected),
+    operator,
+  });
+};

--- a/js/pop-quiz/1.0.1/assertions/deepequal.mjs
+++ b/js/pop-quiz/1.0.1/assertions/deepequal.mjs
@@ -1,0 +1,62 @@
+import TestError from "../testerror.mjs";
+// https://deno.land/x/cotton@v0.6.3/src/utils/deepequal.ts
+const deepEqual = (a, b) => {
+  if (a === b) return true;
+  if (a && b && typeof a == "object" && typeof b == "object") {
+    if (a.constructor !== b.constructor) return false;
+
+    var length, i, keys;
+    if (Array.isArray(a)) {
+      length = a.length;
+      if (length != b.length) return false;
+      for (i = length; i-- !== 0; ) {
+        if (!deepEqual(a[i], b[i])) return false;
+      }
+      return true;
+    }
+
+    if (a.constructor === RegExp) {
+      return a.source === b.source && a.flags === b.flags;
+    }
+    if (a.valueOf !== Object.prototype.valueOf) {
+      return a.valueOf() === b.valueOf();
+    }
+    if (a.toString !== Object.prototype.toString) {
+      return a.toString() === b.toString();
+    }
+
+    keys = Object.keys(a);
+    length = keys.length;
+    if (length !== Object.keys(b).length) return false;
+
+    for (i = length; i-- !== 0; ) {
+      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+    }
+
+    for (i = length; i-- !== 0; ) {
+      var key = keys[i];
+      if (!deepEqual(a[key], b[key])) return false;
+    }
+
+    return true;
+  }
+
+  // true if both NaN, false otherwise
+  return a !== a && b !== b;
+};
+export const DefaultMessage = "should be deep equal";
+export default (
+  actual,
+  expected,
+  message = DefaultMessage,
+  operator = "deepequal"
+) => {
+  if (deepEqual(actual, expected)) {
+    return message;
+  }
+  return new TestError(message, {
+    actual: JSON.stringify(actual),
+    expected: JSON.stringify(expected),
+    operator,
+  });
+};

--- a/js/pop-quiz/1.0.1/assertions/doesnotthrow.mjs
+++ b/js/pop-quiz/1.0.1/assertions/doesnotthrow.mjs
@@ -1,0 +1,14 @@
+import TestError from "../testerror.mjs";
+export const DefaultMessage = "should not throw error";
+export default async (
+  actual,
+  message = DefaultMessage,
+  operator = "doesnotthrow"
+) => {
+  try {
+    await actual();
+    return message;
+  } catch {
+    return new TestError(message, { actual, operator });
+  }
+};

--- a/js/pop-quiz/1.0.1/assertions/equal.mjs
+++ b/js/pop-quiz/1.0.1/assertions/equal.mjs
@@ -1,0 +1,13 @@
+import TestError from "../testerror.mjs";
+export const DefaultMessage = "should be strictly equal";
+export default (
+  actual,
+  expected,
+  message = DefaultMessage,
+  operator = "equal"
+) => {
+  if (actual === expected) {
+    return message;
+  }
+  return new TestError(message, { actual, expected, message, operator });
+};

--- a/js/pop-quiz/1.0.1/assertions/fail.mjs
+++ b/js/pop-quiz/1.0.1/assertions/fail.mjs
@@ -1,0 +1,10 @@
+import TestError from "../testerror.mjs";
+export const DefaultMessage = "should always fail";
+export default (message = DefaultMessage) => {
+  return new TestError(message, {
+    actual: undefined,
+    expected: undefined,
+    message,
+    operator: "fail",
+  });
+};

--- a/js/pop-quiz/1.0.1/assertions/index.mjs
+++ b/js/pop-quiz/1.0.1/assertions/index.mjs
@@ -1,0 +1,11 @@
+export { default as ok } from "./ok.mjs";
+export { default as notok } from "./notok.mjs";
+export { default as equal } from "./equal.mjs";
+export { default as notequal } from "./notequal.mjs";
+export { default as deepequal } from "./deepequal.mjs";
+export { default as pass } from "./pass.mjs";
+export { default as fail } from "./fail.mjs";
+export { default as subtestpass } from "./subtestpass.mjs";
+export { default as subtestfail } from "./subtestfail.mjs";
+export { default as throws } from "./throws.mjs";
+export { default as doesnotthrow } from "./doesnotthrow.mjs";

--- a/js/pop-quiz/1.0.1/assertions/index.mjs
+++ b/js/pop-quiz/1.0.1/assertions/index.mjs
@@ -3,6 +3,7 @@ export { default as notok } from "./notok.mjs";
 export { default as equal } from "./equal.mjs";
 export { default as notequal } from "./notequal.mjs";
 export { default as deepequal } from "./deepequal.mjs";
+export { default as deepdeepequal } from "./deepdeepequal.mjs";
 export { default as pass } from "./pass.mjs";
 export { default as fail } from "./fail.mjs";
 export { default as subtestpass } from "./subtestpass.mjs";

--- a/js/pop-quiz/1.0.1/assertions/notequal.mjs
+++ b/js/pop-quiz/1.0.1/assertions/notequal.mjs
@@ -1,0 +1,13 @@
+import TestError from "../testerror.mjs";
+export const DefaultMessage = "should be strictly not equal";
+export default (
+  actual,
+  unexpected,
+  message = DefaultMessage,
+  operator = "notequal"
+) => {
+  if (actual !== unexpected) {
+    return message;
+  }
+  return new TestError(message, { actual, unexpected, message, operator });
+};

--- a/js/pop-quiz/1.0.1/assertions/notok.mjs
+++ b/js/pop-quiz/1.0.1/assertions/notok.mjs
@@ -1,0 +1,8 @@
+import TestError from "../testerror.mjs";
+export const DefaultMessage = "should be falsy";
+export default (actual, message = DefaultMessage, operator = "notok") => {
+  if (!actual) {
+    return message;
+  }
+  return new TestError(message, { actual, operator });
+};

--- a/js/pop-quiz/1.0.1/assertions/ok.mjs
+++ b/js/pop-quiz/1.0.1/assertions/ok.mjs
@@ -1,0 +1,8 @@
+import TestError from "../testerror.mjs";
+export const DefaultMessage = "should be truthy";
+export default (actual, message = DefaultMessage, operator = "ok") => {
+  if (actual) {
+    return message;
+  }
+  return new TestError(message, { actual, operator });
+};

--- a/js/pop-quiz/1.0.1/assertions/pass.mjs
+++ b/js/pop-quiz/1.0.1/assertions/pass.mjs
@@ -1,0 +1,4 @@
+export const DefaultMessage = "should always pass";
+export default (message = DefaultMessage) => {
+  return message;
+};

--- a/js/pop-quiz/1.0.1/assertions/subtestfail.mjs
+++ b/js/pop-quiz/1.0.1/assertions/subtestfail.mjs
@@ -1,0 +1,16 @@
+import TestError from "../testerror.mjs";
+import { run } from "../TAPRunner.mjs";
+
+export const DefaultMessage = "should fail all subtests";
+export default async (
+  actual,
+  message = DefaultMessage,
+  operator = "subtestfail"
+) => {
+  for await (const result of run(actual)) {
+    if (!(result instanceof TestError)) {
+      return new TestError(message, { actual, operator });
+    }
+  }
+  return message;
+};

--- a/js/pop-quiz/1.0.1/assertions/subtestpass.mjs
+++ b/js/pop-quiz/1.0.1/assertions/subtestpass.mjs
@@ -1,0 +1,16 @@
+import TestError from "../testerror.mjs";
+import { run } from "../TAPRunner.mjs";
+
+export const DefaultMessage = "should pass all subtests";
+export default async (
+  actual,
+  message = DefaultMessage,
+  operator = "subtestpass"
+) => {
+  for await (const result of run(actual)) {
+    if (result instanceof TestError) {
+      return new TestError(message, { actual, operator });
+    }
+  }
+  return message;
+};

--- a/js/pop-quiz/1.0.1/assertions/throws.mjs
+++ b/js/pop-quiz/1.0.1/assertions/throws.mjs
@@ -1,0 +1,14 @@
+import TestError from "../testerror.mjs";
+export const DefaultMessage = "should throw error";
+export default async (
+  actual,
+  message = DefaultMessage,
+  operator = "throws"
+) => {
+  try {
+    await actual();
+  } catch {
+    return message;
+  }
+  return new TestError(message, { actual, operator });
+};

--- a/js/pop-quiz/1.0.1/index.mjs
+++ b/js/pop-quiz/1.0.1/index.mjs
@@ -1,0 +1,6 @@
+import { print } from "./TAPRunner.mjs";
+export default (title, test, primaryTest = true) =>
+  test
+    ? print(test, title, undefined, undefined, primaryTest)
+    : print(title, undefined, undefined, undefined, primaryTest);
+export * from "./assertions/index.mjs";

--- a/js/pop-quiz/1.0.1/package.json
+++ b/js/pop-quiz/1.0.1/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "pop-quiz",
+  "version": "1.0.1",
+  "description": "A context-independent, zero-dependency TAP testing framework inspired by tape. Runs unchanged in Node, Deno, and the browser.",
+  "type": "module",
+  "main": "./index.mjs",
+  "exports": {
+    ".": "./index.mjs",
+    "./TAPRunner": "./TAPRunner.mjs",
+    "./assertions": "./assertions/index.mjs",
+    "./unique": "./unique/index.mjs"
+  },
+  "files": [
+    "index.mjs",
+    "TAPRunner.mjs",
+    "testerror.mjs",
+    "assertions",
+    "unique",
+    "readme.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publish": true,
+  "keywords": [
+    "test",
+    "testing",
+    "tape",
+    "TAP",
+    "assertions",
+    "zero-dependency"
+  ],
+  "author": "John Henry",
+  "license": "ISC",
+  "homepage": "https://github.com/johnhenry/pop-quiz",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/johnhenry/pop-quiz.git"
+  }
+}

--- a/js/pop-quiz/1.0.1/popquiz.jest.test.mjs
+++ b/js/pop-quiz/1.0.1/popquiz.jest.test.mjs
@@ -1,0 +1,190 @@
+import quiz, {
+  ok,
+  notok,
+  equal,
+  notequal,
+  deepequal,
+  pass,
+  fail,
+  subtestpass,
+  subtestfail,
+  throws,
+  doesnotthrow,
+} from "./index.mjs";
+import { run, print } from "./TAPRunner.mjs";
+import TestError from "./testerror.mjs";
+import { unique } from "./unique/index.mjs";
+import { DefaultMessage as DefaultMessageOK } from "./assertions/ok.mjs";
+import { DefaultMessage as DefaultMessageEqual } from "./assertions/equal.mjs";
+
+describe("pop-quiz assertions", () => {
+  it("passes each assertion when its condition is satisfied", async () => {
+    const results = [
+      pass("pass should always pass"),
+      ok(true, "ok passes on truthy"),
+      notok(false, "notok passes on falsy"),
+      equal(1, 1, "equal passes on strict equality"),
+      notequal(1, 2, "notequal passes on strict inequality"),
+      deepequal({ a: 1, b: 0 }, { b: 0, a: 1 }, "deepequal passes on deep equality"),
+      await subtestpass(function* () {
+        yield pass();
+      }, "subtestpass passes when subtest passes"),
+      await subtestfail(function* () {
+        yield fail();
+      }, "subtestfail passes when subtest fails"),
+      await throws(() => {
+        throw new Error("");
+      }, "throws passes when function throws"),
+      await doesnotthrow(() => {}, "doesnotthrow passes when function does not throw"),
+    ];
+    for (const result of results) {
+      expect(result).not.toBeInstanceOf(TestError);
+      expect(typeof result).toBe("string");
+    }
+  });
+
+  it("fails each assertion when its condition is violated", async () => {
+    const results = [
+      fail(),
+      ok(false),
+      notok(true),
+      equal(1, 2),
+      notequal(1, 1),
+      deepequal({ a: 1, b: 0 }, { a: 1 }),
+      await subtestpass(function* () {
+        yield fail();
+      }),
+      await subtestfail(function* () {
+        yield pass();
+      }),
+      await throws(() => {}),
+      await doesnotthrow(() => {
+        throw new Error("");
+      }),
+    ];
+    for (const result of results) {
+      expect(result).toBeInstanceOf(TestError);
+    }
+  });
+
+  it("uses default messages when none are given", () => {
+    expect(ok(1)).toBe(DefaultMessageOK);
+    expect(equal(1, 1)).toBe(DefaultMessageEqual);
+  });
+
+  it("supports async assertion targets", async () => {
+    expect(
+      await throws(async () => {
+        throw new Error("boom");
+      })
+    ).not.toBeInstanceOf(TestError);
+    expect(await doesnotthrow(async () => 1)).not.toBeInstanceOf(TestError);
+  });
+});
+
+describe("pop-quiz run", () => {
+  it("yields raw results (message strings and TestErrors)", async () => {
+    const outputs = [];
+    for await (const output of run(function* () {
+      yield ok(true, "first");
+      yield ok(false, "second");
+    })) {
+      outputs.push(output);
+    }
+    expect(outputs).toHaveLength(2);
+    expect(outputs[0]).toBe("first");
+    expect(outputs[1]).toBeInstanceOf(TestError);
+    expect(outputs[1].message).toBe("second");
+  });
+
+  it("yields the title first when given", async () => {
+    const outputs = [];
+    for await (const output of run(function* () {
+      yield pass("only");
+    }, "my title")) {
+      outputs.push(output);
+    }
+    expect(outputs[0]).toBe("my title");
+    expect(outputs[1]).toBe("only");
+  });
+
+  it("supports plan() and rejects calling plan twice", async () => {
+    const outputs = [];
+    for await (const output of run(function* (plan) {
+      plan(2);
+      yield pass("a");
+      yield pass("b");
+    })) {
+      outputs.push(output);
+    }
+    expect(outputs).toEqual(["a", "b"]);
+    await expect(async () => {
+      for await (const output of run(function* (plan) {
+        plan(1);
+        plan(1);
+        yield pass();
+      })) {
+        void output;
+      }
+    }).rejects.toThrow("do not call plan more than once");
+  });
+});
+
+describe("pop-quiz print (default export)", () => {
+  it("prints TAP output for passing and failing assertions", async () => {
+    const logs = [];
+    const errors = [];
+    await print(
+      function* () {
+        yield ok(true, "yes");
+        yield ok(false, "no");
+      },
+      "tap title",
+      (line) => logs.push(line),
+      (line) => errors.push(line)
+    );
+    const all = logs.join("\n");
+    expect(logs[0]).toBe("TAP version 13");
+    expect(all).toContain("tap title");
+    expect(all).toContain("ok 1 - yes");
+    expect(all).toContain("not ok 2 - no");
+    expect(all).toContain("# tests 2");
+    expect(all).toContain("# pass  1");
+    expect(all).toContain("# fail  1");
+  });
+
+  it("quiz(title, test) resolves without throwing", async () => {
+    const log = () => {};
+    // The default export routes through print(); silence console output.
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = log;
+    console.error = log;
+    try {
+      await quiz("quiet quiz", function* () {
+        yield pass();
+      });
+      await quiz(function* () {
+        yield pass();
+      });
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+  });
+});
+
+describe("pop-quiz unique", () => {
+  it("generates unique values of each kind", () => {
+    const numbers = unique();
+    expect(numbers.next().value).toBe(0);
+    expect(numbers.next().value).toBe(1);
+    const strings = unique("string", "id");
+    expect(strings.next().value).toBe("id:0");
+    expect(strings.next().value).toBe("id:1");
+    const bigints = unique("bigint");
+    expect(bigints.next().value).toBe(0n);
+    const symbols = unique("symbol", "sym");
+    expect(symbols.next().value).toBe(Symbol.for("sym:0"));
+  });
+});

--- a/js/pop-quiz/1.0.1/popquiz.jest.test.mjs
+++ b/js/pop-quiz/1.0.1/popquiz.jest.test.mjs
@@ -4,6 +4,7 @@ import quiz, {
   equal,
   notequal,
   deepequal,
+  deepdeepequal,
   pass,
   fail,
   subtestpass,
@@ -153,6 +154,36 @@ describe("pop-quiz print (default export)", () => {
     expect(all).toContain("# fail  1");
   });
 
+  it("sets process.exitCode on failure but not on success", async () => {
+    const originalExitCode = process.exitCode;
+    const noop = () => {};
+    try {
+      process.exitCode = undefined;
+      await print(
+        function* () {
+          yield pass();
+        },
+        undefined,
+        noop,
+        noop
+      );
+      expect(process.exitCode).toBeUndefined();
+
+      process.exitCode = undefined;
+      await print(
+        function* () {
+          yield fail();
+        },
+        undefined,
+        noop,
+        noop
+      );
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = originalExitCode;
+    }
+  });
+
   it("quiz(title, test) resolves without throwing", async () => {
     const log = () => {};
     // The default export routes through print(); silence console output.
@@ -171,6 +202,67 @@ describe("pop-quiz print (default export)", () => {
       console.log = originalLog;
       console.error = originalError;
     }
+  });
+});
+
+describe("pop-quiz assertions: deepdeepequal", () => {
+  it("passes for arrays of objects regardless of key order (same as deepequal)", () => {
+    const result = deepdeepequal(
+      [{ a: true, b: false }],
+      [{ b: false, a: true }]
+    );
+    expect(result).not.toBeInstanceOf(TestError);
+  });
+
+  it("catches Map content that deepequal cannot see", () => {
+    const a = new Map([
+      ["x", 1],
+      ["y", 2],
+    ]);
+    const b = new Map([
+      ["x", 1],
+      ["y", 999],
+    ]);
+    // deepequal has no visibility into Map entries: two Maps with
+    // different values compare equal because neither has own enumerable
+    // string keys.
+    expect(deepequal(a, b)).not.toBeInstanceOf(TestError);
+    expect(deepdeepequal(a, b)).toBeInstanceOf(TestError);
+  });
+
+  it("passes for Maps with equal content, including nested values", () => {
+    const a = new Map([["k", { x: 1, y: [1, 2] }]]);
+    const b = new Map([["k", { y: [1, 2], x: 1 }]]);
+    expect(deepdeepequal(a, b)).not.toBeInstanceOf(TestError);
+  });
+
+  it("catches Set content that deepequal cannot see", () => {
+    const a = new Set([1, 2, 3]);
+    const b = new Set([1, 2, 4]);
+    expect(deepequal(a, b)).not.toBeInstanceOf(TestError);
+    expect(deepdeepequal(a, b)).toBeInstanceOf(TestError);
+  });
+
+  it("passes for Sets with equal content regardless of insertion order", () => {
+    const a = new Set([{ id: 1 }, { id: 2 }]);
+    const b = new Set([{ id: 2 }, { id: 1 }]);
+    expect(deepdeepequal(a, b)).not.toBeInstanceOf(TestError);
+  });
+
+  it("does not stack-overflow on matching circular references", () => {
+    const a = { name: "a" };
+    a.self = a;
+    const b = { name: "a" };
+    b.self = b;
+    expect(deepdeepequal(a, b)).not.toBeInstanceOf(TestError);
+  });
+
+  it("still fails on non-circular mismatches", () => {
+    const a = { name: "a" };
+    a.self = a;
+    const b = { name: "different" };
+    b.self = b;
+    expect(deepdeepequal(a, b)).toBeInstanceOf(TestError);
   });
 });
 

--- a/js/pop-quiz/1.0.1/readme.md
+++ b/js/pop-quiz/1.0.1/readme.md
@@ -1,0 +1,100 @@
+# Pop-Quiz
+
+> **Source of truth:** development happens at
+> [github.com/johnhenry/pop-quiz](https://github.com/johnhenry/pop-quiz).
+> This directory is a snapshot published here for the CDN import URL and
+> npm release; it will not track every upstream commit.
+
+A context-independent, zero-dependency testing framework inspired by
+[tape](https://github.com/substack/tape). Tests run in the same context as
+your application — Node, Deno, or the browser — with no binaries or
+transformations, and report using the
+[Test Anything Protocol](https://testanything.org/).
+
+## Import Syntax
+
+Import directly from this site:
+
+```javascript
+import quiz, {
+  ok,
+  equal,
+} from "https://johnhenry.github.io/lib/js/pop-quiz/1.0.1/index.mjs";
+```
+
+or install via npm (`npm install pop-quiz`) and import by name:
+
+```javascript
+import quiz, { ok, equal } from "pop-quiz";
+```
+
+## Usage
+
+The default export — the "quiz" function — runs a group of assertions.
+It takes a title and a (possibly asynchronous) generator, called a "test".
+Assertion results are yielded from within the body of the test.
+
+```javascript
+import quiz, { ok, notok, equal, deepequal } from "pop-quiz";
+
+await quiz("basic arithmetic", function* () {
+  yield ok(1 + 1, "sums should be truthy");
+  yield notok(1 - 1, "differences should be falsy");
+  yield equal(2 + 2, 4);
+  yield deepequal({ a: 1, b: 2 }, { b: 2, a: 1 });
+});
+```
+
+The title may be omitted; passing just a test works too:
+
+```javascript
+await quiz(function* () {
+  yield ok(true);
+});
+```
+
+### Included Assertions
+
+Each assertion returns its message on success and a `TestError` on failure.
+
+| assertion                                | passes when                            |
+| ---------------------------------------- | -------------------------------------- |
+| `pass(message?)`                          | always                                 |
+| `fail(message?)`                          | never                                  |
+| `ok(actual, message?)`                    | `actual` is truthy                     |
+| `notok(actual, message?)`                 | `actual` is falsy                      |
+| `equal(actual, expected, message?)`       | `actual === expected`                  |
+| `notequal(actual, unexpected, message?)`  | `actual !== unexpected`                |
+| `deepequal(actual, expected, message?)`   | `actual` deeply equals `expected`      |
+| `throws(fn, message?)`                    | calling (and awaiting) `fn` throws     |
+| `doesnotthrow(fn, message?)`              | calling (and awaiting) `fn` succeeds   |
+| `subtestpass(test, message?)`             | every assertion in `test` passes       |
+| `subtestfail(test, message?)`             | every assertion in `test` fails        |
+
+Writing your own assertion is easy: return a message on success and a
+`TestError` (importable from `./testerror.mjs`) on failure.
+
+### Lower-level API
+
+`TAPRunner.mjs` exports the underlying machinery — most notably
+`run(test, title?, ...formatters)`, an async generator yielding raw results,
+and `print(test, title?)`, which logs TAP-formatted output.
+
+```javascript
+import { run } from "https://johnhenry.github.io/lib/js/pop-quiz/1.0.1/TAPRunner.mjs";
+
+for await (const result of run(function* () {
+  yield ok(true);
+})) {
+  console.log(result);
+}
+```
+
+`unique/index.mjs` exports a `unique` generator for producing unique
+numbers, strings, bigints, or symbols — handy for generating test fixtures.
+
+## Demonstration
+
+See this module's own test suite,
+[popquiz.jest.test.mjs](./popquiz.jest.test.mjs), for a complete tour of the
+API.

--- a/js/pop-quiz/1.0.1/readme.md
+++ b/js/pop-quiz/1.0.1/readme.md
@@ -66,6 +66,7 @@ Each assertion returns its message on success and a `TestError` on failure.
 | `equal(actual, expected, message?)`       | `actual === expected`                  |
 | `notequal(actual, unexpected, message?)`  | `actual !== unexpected`                |
 | `deepequal(actual, expected, message?)`   | `actual` deeply equals `expected`      |
+| `deepdeepequal(actual, expected, message?)` | `actual` deeply equals `expected`, including `Map`/`Set` contents and matching circular references (things plain `deepequal` can't see) |
 | `throws(fn, message?)`                    | calling (and awaiting) `fn` throws     |
 | `doesnotthrow(fn, message?)`              | calling (and awaiting) `fn` succeeds   |
 | `subtestpass(test, message?)`             | every assertion in `test` passes       |

--- a/js/pop-quiz/1.0.1/testerror.mjs
+++ b/js/pop-quiz/1.0.1/testerror.mjs
@@ -1,0 +1,9 @@
+export default class extends Error {
+  constructor(message, val = {}) {
+    super(message);
+    this.val = val;
+  }
+  [Symbol.iterator]() {
+    return Object.entries(this.val).values();
+  }
+}

--- a/js/pop-quiz/1.0.1/unique/index.mjs
+++ b/js/pop-quiz/1.0.1/unique/index.mjs
@@ -1,0 +1,23 @@
+export const unique = function* (kind = Number, prefix = "") {
+  let i = 0;
+  switch (kind) {
+    case "symbol":
+      while (true) {
+        yield Symbol.for(`${prefix}:${i++}`);
+      }
+    case "string":
+      while (true) {
+        yield String(`${prefix}:${i++}`);
+      }
+    case "bigint":
+      while (true) {
+        yield BigInt(i++);
+      }
+    case "number":
+    default:
+      while (true) {
+        yield i++;
+      }
+  }
+};
+export default unique;


### PR DESCRIPTION
## Why
While double-checking the pop-quiz graduation (#9), found that `johnhenry/pop-quiz` is a separate, actively-maintained repo — it's why npm already had versions 0.0.6 and 0.0.7 that lib's vendored copy (frozen at 0.0.5 since 2022) never received. Confirmed the runtime code is byte-identical between lib's 0.0.5 and the standalone repo's 0.0.7, so the already-published `1.0.0` isn't a functional regression.

## What
Metadata/docs-only `1.0.1` (no code changes): `package.json` homepage/repository and the readme now point at [github.com/johnhenry/pop-quiz](https://github.com/johnhenry/pop-quiz) as the source of truth. lib's copy stays for the CDN import URL and npm release, but won't necessarily track every upstream commit.

**Not carried forward:** the standalone repo's `tests/deep.mjs` is dead code — not wired into its own `popquiz.test.mjs` entry point, and it imports a `deepdeepequal` export that doesn't exist in `index.mjs`. Copying it would ship a broken test; worth fixing upstream instead.

## Verification
211 tests pass (17 suites). `npm run build && node scripts/verify-contract.mjs` green — 977 paths intact; the only new URL is the additive `js/pop-quiz/1.0.1/` page.