### PR TITLE
liedenticon 1.0.1: point at the standalone repo as canonical source

### DIFF
--- a/contract/generated-files.txt
+++ b/contract/generated-files.txt
@@ -167,6 +167,7 @@ js/iterator-zip/index.html
 js/json-form.component/index.html
 js/liedenticon/0.0.4/index.html
 js/liedenticon/1.0.0/index.html
+js/liedenticon/1.0.1/index.html
 js/liedenticon/index.html
 js/linked-list/index.html
 js/live-query-selector/0.0.0/index.html

--- a/js/liedenticon/1.0.1/color-to-array.mjs
+++ b/js/liedenticon/1.0.1/color-to-array.mjs
@@ -1,0 +1,48 @@
+//
+export default (input) => {
+  let red = 0;
+  let green = 0;
+  let blue = 0;
+  let alpha = 255;
+  if (typeof input === "string") {
+    if (input[0] === "#") {
+      input = input.substr(1);
+    }
+  } else if (typeof input === "number") {
+    input = input.toString(16);
+  }
+  if (!input.length) {
+    return [red, green, blue, alpha];
+  }
+
+  if (input.length === 5 || input.length === 7 || input.length > 8) {
+    throw new Error(`color of length ${input.length} not supported`);
+  }
+
+  if (input.length < 3) {
+    //1,2
+    red = green = blue = parseInt(input[0].repeat(2), 16);
+    if (input.length > 1) {
+      alpha = parseInt(input[1].repeat(2), 16);
+    }
+  } else if (input.length < 5) {
+    //3, 4
+    red = parseInt(input.substr(0, 1).repeat(2), 16);
+    green = parseInt(input.substr(1, 1).repeat(2), 16);
+    blue = parseInt(input.substr(2, 1).repeat(2), 16);
+    if (input.length > 3) {
+      alpha = parseInt(input.substr(3, 1).repeat(2), 16);
+    }
+  } else if (input.length < 9) {
+    //6, 8
+    red = parseInt(input.substr(0, 2), 16);
+    green = parseInt(input.substr(2, 2), 16);
+    blue = parseInt(input.substr(4, 2), 16);
+    if (input.length > 6) {
+      alpha = parseInt(input.substr(6, 2), 16);
+    }
+  } else {
+    throw new Error(`color of length ${input.length} not supported`);
+  }
+  return [red, green, blue, alpha];
+};

--- a/js/liedenticon/1.0.1/defaults.mjs
+++ b/js/liedenticon/1.0.1/defaults.mjs
@@ -1,0 +1,7 @@
+//
+export const padding = 0;
+export const size = 64;
+export const saturation = 0.75;
+export const brightness = 0.5;
+export const background = [0, 0, 0, 0];
+export const foreground = undefined;

--- a/js/liedenticon/1.0.1/graphic.mjs
+++ b/js/liedenticon/1.0.1/graphic.mjs
@@ -1,0 +1,109 @@
+//
+import * as defaults from "./defaults.mjs";
+import hsl2rgb from "./hsl2rgb.mjs";
+
+const render = (
+  hash,
+  { size, padding, background, foreground },
+  image,
+  rectangle
+) => {
+  let baseMargin = Math.floor(size * padding);
+  let cell = Math.floor((size - baseMargin * 2) / 5);
+  padding = Math.floor((size - cell * 5) / 2);
+  let bg = image.color(background);
+  let fg = image.color(foreground);
+
+  // the first 15 characters of the hash control the pixels (even/odd)
+  // they are drawn down the middle first, then mirrored outwards
+  let i, color;
+  for (i = 0; i < 15; i++) {
+    color = parseInt(hash.charAt(i), 16) % 2 ? bg : fg;
+    if (i < 5) {
+      rectangle(
+        2 * cell + padding,
+        i * cell + padding,
+        cell,
+        cell,
+        color,
+        image
+      );
+    } else if (i < 10) {
+      rectangle(
+        1 * cell + padding,
+        (i - 5) * cell + padding,
+        cell,
+        cell,
+        color,
+        image
+      );
+      rectangle(
+        3 * cell + padding,
+        (i - 5) * cell + padding,
+        cell,
+        cell,
+        color,
+        image
+      );
+    } else if (i < 15) {
+      rectangle(
+        0 * cell + padding,
+        (i - 10) * cell + padding,
+        cell,
+        cell,
+        color,
+        image
+      );
+      rectangle(
+        4 * cell + padding,
+        (i - 10) * cell + padding,
+        cell,
+        cell,
+        color,
+        image
+      );
+    }
+  }
+  return image;
+};
+export { render };
+
+export default class {
+  constructor(
+    hash,
+    {
+      size = defaults.size,
+      padding = defaults.padding,
+      saturation = defaults.saturation,
+      brightness = defaults.brightness,
+      background = defaults.background,
+      foreground = defaults.foreground,
+    } = defaults
+  ) {
+    if (typeof hash !== "string") {
+      throw new Error("hash must be a string");
+    }
+    hash = hash.padEnd(15, " ");
+    if (typeof padding === "string") {
+      const index = padding.indexOf("%");
+      if (index > 0) {
+        padding = padding.substr(0, index);
+        padding = Number(padding) / 100;
+      } else {
+        padding = Number(padding);
+      }
+    }
+    // foreground defaults to last 7 chars as hue at 70% saturation, 50% brightness
+    foreground =
+      foreground ||
+      hsl2rgb(
+        parseInt(hash.substr(-7), 16) / 0xfffffff,
+        saturation,
+        brightness
+      );
+    this.image = this.renderImage(hash, size, padding, background, foreground);
+  }
+  renderImage(hash, size, padding, background, foreground) {
+    return null;
+  }
+}

--- a/js/liedenticon/1.0.1/hsl2rgb.mjs
+++ b/js/liedenticon/1.0.1/hsl2rgb.mjs
@@ -1,0 +1,18 @@
+//
+export default (h, s, b) => {
+  h *= 6;
+  const S = [
+    (b += s *= b < 0.5 ? b : 1 - b),
+    b - (h % 1) * s * 2,
+    (b -= s *= 2),
+    b,
+    b + (h % 1) * s,
+    b + s,
+  ];
+
+  return [
+    S[~~h % 6] * 255, // red
+    S[(h | 16) % 6] * 255, // green
+    S[(h | 8) % 6] * 255, // blue
+  ];
+};

--- a/js/liedenticon/1.0.1/index.d.ts
+++ b/js/liedenticon/1.0.1/index.d.ts
@@ -1,0 +1,43 @@
+export type Color =
+  | string
+  | number
+  | [number, number, number]
+  | [number, number, number, number];
+
+export interface GraphicOptions {
+  /** Image width/height in pixels. Default 64. */
+  size?: number;
+  /** Padding as a fraction of size, a numeric string, or a percentage string such as "20%". Default 0. */
+  padding?: number | string;
+  /** Foreground color saturation (0–1) when derived from the hash. Default 0.75. */
+  saturation?: number;
+  /** Foreground color brightness (0–1) when derived from the hash. Default 0.5. */
+  brightness?: number;
+  /** Background color. Default transparent ([0, 0, 0, 0]). */
+  background?: Color;
+  /** Foreground color. Defaults to a hue derived from the hash. */
+  foreground?: Color;
+}
+
+/**
+ * A hash represented as an SVG.
+ */
+export class SVG {
+  constructor(hash: string, options?: GraphicOptions);
+  /**
+   * @param preamble prepend a data-URI preamble. Default false.
+   * @param base64 base64-encode the SVG. Default false.
+   */
+  toString(preamble?: boolean, base64?: boolean): string;
+}
+
+/**
+ * A hash represented as a PNG.
+ */
+export class PNG {
+  constructor(hash: string, options?: GraphicOptions);
+  /**
+   * @param preamble prepend a data-URI preamble. Default true.
+   */
+  toString(preamble?: boolean): string;
+}

--- a/js/liedenticon/1.0.1/index.mjs
+++ b/js/liedenticon/1.0.1/index.mjs
@@ -1,0 +1,39 @@
+/* eslint-disable */
+
+/**
+ * Liedenticons 0.0.0
+ * http://github.com/johnhenry/liedenticons
+ * @copyright Copyright (c) 2017, John Henry
+ * @copyright Copyright (c) 2017, Stewart Lord
+ * @copyright Copyright (c) 2010, Robert Eisele <robert@xarg.org>
+ * Released under the BSD license
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+
+/**
+ * @class SVG
+ * @description A hash represented as an SVG
+ * @param {string} hash - unique string
+ * @param {object} options - graphicical options
+ * @extends liedenticon/graphic
+ * @example
+ * import {SVG} from "Liedenticons";
+ * const svg = document.createElement("SVG");
+ * document.appendChild(svg);
+ * svg.outerHTML = new SVG("efb8c90a13f7a1fdc4910");
+ */
+export { default as SVG } from "./svg/index.mjs";
+
+/**
+ * @class PNG
+ * @description A hash represented as an PNG
+ * @param {string} hash - unique string
+ * @param {object} options - graphicical options
+ * @extends liedenticon/graphic
+ * @example
+ * import {PNG} from "Liedenticons";
+ * const img = document.createElement("IMG");
+ * img.src = new PNG("efb8c90a13f7a1fdc4910");
+ * document.appendChild(img);
+ */
+export { default as PNG } from "./png/index.mjs";

--- a/js/liedenticon/1.0.1/liedenticon.jest.test.mjs
+++ b/js/liedenticon/1.0.1/liedenticon.jest.test.mjs
@@ -1,0 +1,89 @@
+import { SVG, PNG } from "./index.mjs";
+import colorToArray from "./color-to-array.mjs";
+import hsl2rgb from "./hsl2rgb.mjs";
+
+const HASH = "efb8c90a13f7a1fdc4910";
+
+describe("liedenticon SVG", () => {
+  it("generates an svg string by default", () => {
+    const svg = String(new SVG(HASH));
+    expect(svg.startsWith("<svg xmlns=")).toBe(true);
+    expect(svg.endsWith("</svg>")).toBe(true);
+    expect(svg).toContain("<rect");
+  });
+  it("prepends a data-URI preamble when toString is passed true", () => {
+    expect(new SVG(HASH).toString(true).startsWith("data:image/svg+xml;utf8,<svg")).toBe(
+      true
+    );
+  });
+  it("base64 encodes when toString is passed two truthy arguments", () => {
+    const output = new SVG(HASH).toString(true, true);
+    expect(output.startsWith("data:image/svg+xml;base64,")).toBe(true);
+    const decoded = atob(output.slice("data:image/svg+xml;base64,".length));
+    expect(decoded).toBe(new SVG(HASH).toString());
+  });
+  it("is deterministic per hash and varies across hashes", () => {
+    expect(String(new SVG(HASH))).toBe(String(new SVG(HASH)));
+    expect(String(new SVG(HASH))).not.toBe(
+      String(new SVG("000000000000000000000"))
+    );
+  });
+  it("honors size, foreground, and percentage padding options", () => {
+    const svg = String(
+      new SVG(HASH, { size: 128, padding: "20%", foreground: "#36c" })
+    );
+    expect(svg).toContain("width='128'");
+    expect(svg).toContain("height='128'");
+    expect(svg).toContain("rgba(51,102,204,1)");
+  });
+  it("rejects non-string hashes", () => {
+    expect(() => new SVG(12345)).toThrow("hash must be a string");
+  });
+});
+
+describe("liedenticon PNG", () => {
+  it("generates a base64 data URI by default", () => {
+    const output = String(new PNG(HASH));
+    expect(output.startsWith("data:image/png;base64,")).toBe(true);
+  });
+  it("drops the preamble when toString is passed false", () => {
+    const raw = new PNG(HASH).toString(false);
+    expect(raw.startsWith("data:")).toBe(false);
+    const bytes = Buffer.from(raw, "base64");
+    // PNG magic number
+    expect([...bytes.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+  it("is deterministic per hash", () => {
+    expect(String(new PNG(HASH))).toBe(String(new PNG(HASH)));
+  });
+  it("rejects non-string hashes", () => {
+    expect(() => new PNG(null)).toThrow("hash must be a string");
+  });
+});
+
+describe("liedenticon colorToArray", () => {
+  it("parses hex colors of length 1, 2, 3, 4, 6, and 8", () => {
+    expect(colorToArray("f")).toEqual([255, 255, 255, 255]);
+    expect(colorToArray("f8")).toEqual([255, 255, 255, 136]);
+    expect(colorToArray("#fff")).toEqual([255, 255, 255, 255]);
+    expect(colorToArray("123f")).toEqual([17, 34, 51, 255]);
+    expect(colorToArray("336699")).toEqual([51, 102, 153, 255]);
+    expect(colorToArray("33669980")).toEqual([51, 102, 153, 128]);
+  });
+  it("parses numeric input as hex", () => {
+    expect(colorToArray(0xffffff)).toEqual([255, 255, 255, 255]);
+  });
+  it("rejects unsupported lengths", () => {
+    expect(() => colorToArray("12345")).toThrow("not supported");
+    expect(() => colorToArray("123456789")).toThrow("not supported");
+  });
+});
+
+describe("liedenticon hsl2rgb", () => {
+  it("converts hue/saturation/brightness to rgb", () => {
+    const [r, g, b] = hsl2rgb(0, 1, 0.5);
+    expect(Math.round(r)).toBe(255);
+    expect(Math.round(g)).toBe(0);
+    expect(Math.round(b)).toBe(0);
+  });
+});

--- a/js/liedenticon/1.0.1/package.json
+++ b/js/liedenticon/1.0.1/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "liedenticon",
+  "version": "1.0.1",
+  "description": "Transform a string into a unique identicon image, as an SVG or PNG data URI. A refinement of Identicon with separate SVG/PNG classes, flexible hex color support, and percentage padding.",
+  "type": "module",
+  "main": "./index.mjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
+    },
+    "./svg": "./svg/index.mjs",
+    "./png": "./png/index.mjs",
+    "./graphic": "./graphic.mjs"
+  },
+  "files": [
+    "index.mjs",
+    "index.d.ts",
+    "color-to-array.mjs",
+    "defaults.mjs",
+    "graphic.mjs",
+    "hsl2rgb.mjs",
+    "svg",
+    "png",
+    "readme.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publish": true,
+  "keywords": [
+    "identicon",
+    "avatar",
+    "svg",
+    "png",
+    "hash",
+    "image",
+    "data-uri"
+  ],
+  "author": "John Henry",
+  "license": "MIT",
+  "homepage": "https://github.com/johnhenry/liedenticon",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/johnhenry/liedenticon.git"
+  }
+}

--- a/js/liedenticon/1.0.1/png/image.mjs
+++ b/js/liedenticon/1.0.1/png/image.mjs
@@ -1,0 +1,230 @@
+//
+import colorToArray from "../color-to-array.mjs";
+// helper functions for that ctx
+const write = (buffer, offset, ...strings) => {
+  for (const string of strings) {
+    for (var j = 0; j < string.length; j++) {
+      buffer[offset++] = string.charAt(j);
+    }
+  }
+};
+
+const byte2 = (w) => {
+  return String.fromCharCode((w >> 8) & 255, w & 255);
+};
+
+const byte4 = (w) => {
+  return String.fromCharCode(
+    (w >> 24) & 255,
+    (w >> 16) & 255,
+    (w >> 8) & 255,
+    w & 255
+  );
+};
+
+const byte2lsb = (w) => {
+  return String.fromCharCode(w & 255, (w >> 8) & 255);
+};
+
+// modified from original source to support NPM
+export default class {
+  constructor(width, height, depth) {
+    this.width = width;
+    this.height = height;
+    this.depth = depth;
+
+    // pixel data and row filter identifier size
+    this.pix_size = height * (width + 1);
+
+    // deflate header, pix_size, block headers, adler32 checksum
+    this.data_size =
+      2 + this.pix_size + 5 * Math.floor((0xfffe + this.pix_size) / 0xffff) + 4;
+
+    // offsets and sizes of Png chunks
+    this.ihdr_offs = 0; // IHDR offset and size
+    this.ihdr_size = 4 + 4 + 13 + 4;
+    this.plte_offs = this.ihdr_offs + this.ihdr_size; // PLTE offset and size
+    this.plte_size = 4 + 4 + 3 * depth + 4;
+    this.trns_offs = this.plte_offs + this.plte_size; // tRNS offset and size
+    this.trns_size = 4 + 4 + depth + 4;
+    this.idat_offs = this.trns_offs + this.trns_size; // IDAT offset and size
+    this.idat_size = 4 + 4 + this.data_size + 4;
+    this.iend_offs = this.idat_offs + this.idat_size; // IEND offset and size
+    this.iend_size = 4 + 4 + 4;
+    this.buffer_size = this.iend_offs + this.iend_size; // total PNG size
+
+    this.buffer = [];
+    this.palette = new Object();
+    this.pindex = 0;
+
+    this._crc32 = [];
+
+    // initialize buffer with zero bytes
+    for (var i = 0; i < this.buffer_size; i++) {
+      this.buffer[i] = "\x00";
+    }
+
+    // initialize non-zero elements
+    write(
+      this.buffer,
+      this.ihdr_offs,
+      byte4(this.ihdr_size - 12),
+      "IHDR",
+      byte4(width),
+      byte4(height),
+      "\x08\x03"
+    );
+    write(this.buffer, this.plte_offs, byte4(this.plte_size - 12), "PLTE");
+    write(this.buffer, this.trns_offs, byte4(this.trns_size - 12), "tRNS");
+    write(this.buffer, this.idat_offs, byte4(this.idat_size - 12), "IDAT");
+    write(this.buffer, this.iend_offs, byte4(this.iend_size - 12), "IEND");
+
+    // initialize deflate header
+    var header = ((8 + (7 << 4)) << 8) | (3 << 6);
+    header += 31 - (header % 31);
+
+    write(this.buffer, this.idat_offs + 8, byte2(header));
+
+    // initialize deflate block headers
+    for (var i = 0; (i << 16) - 1 < this.pix_size; i++) {
+      var size, bits;
+      if (i + 0xffff < this.pix_size) {
+        size = 0xffff;
+        bits = "\x00";
+      } else {
+        size = this.pix_size - (i << 16) - i;
+        bits = "\x01";
+      }
+      write(
+        this.buffer,
+        this.idat_offs + 8 + 2 + (i << 16) + (i << 2),
+        bits,
+        byte2lsb(size),
+        byte2lsb(~size)
+      );
+    }
+
+    /* Create crc32 lookup table */
+    for (var i = 0; i < 256; i++) {
+      var c = i;
+      for (var j = 0; j < 8; j++) {
+        if (c & 1) {
+          c = -306674912 ^ ((c >> 1) & 0x7fffffff);
+        } else {
+          c = (c >> 1) & 0x7fffffff;
+        }
+      }
+      this._crc32[i] = c;
+    }
+
+    // compute the index into a png for a given pixel
+    this.index = function (x, y) {
+      var i = y * (this.width + 1) + x + 1;
+      var j = this.idat_offs + 8 + 2 + 5 * Math.floor(i / 0xffff + 1) + i;
+      return j;
+    };
+
+    // convert a color and build up the palette
+    this.color = function (input) {
+      if (typeof input !== "object") {
+        input = colorToArray(input);
+      }
+      let [red, green, blue, alpha] = input;
+      alpha = alpha >= 0 ? alpha : 255;
+      var color = (((((alpha << 8) | red) << 8) | green) << 8) | blue;
+      if (typeof this.palette[color] == "undefined") {
+        if (this.pindex == this.depth) return "\x00";
+
+        var ndx = this.plte_offs + 8 + 3 * this.pindex;
+
+        this.buffer[ndx + 0] = String.fromCharCode(red);
+        this.buffer[ndx + 1] = String.fromCharCode(green);
+        this.buffer[ndx + 2] = String.fromCharCode(blue);
+        this.buffer[this.trns_offs + 8 + this.pindex] =
+          String.fromCharCode(alpha);
+
+        this.palette[color] = String.fromCharCode(this.pindex++);
+      }
+      return this.palette[color];
+    };
+  }
+  // output a PNG string, Base64 encoded
+  getBase64() {
+    var s = this.getDump();
+
+    var ch =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+    var c1, c2, c3, e1, e2, e3, e4;
+    var l = s.length;
+    var i = 0;
+    var r = "";
+
+    do {
+      c1 = s.charCodeAt(i);
+      e1 = c1 >> 2;
+      c2 = s.charCodeAt(i + 1);
+      e2 = ((c1 & 3) << 4) | (c2 >> 4);
+      c3 = s.charCodeAt(i + 2);
+      if (l < i + 2) {
+        e3 = 64;
+      } else {
+        e3 = ((c2 & 0xf) << 2) | (c3 >> 6);
+      }
+      if (l < i + 3) {
+        e4 = 64;
+      } else {
+        e4 = c3 & 0x3f;
+      }
+      r += ch.charAt(e1) + ch.charAt(e2) + ch.charAt(e3) + ch.charAt(e4);
+    } while ((i += 3) < l);
+    return r;
+  }
+  // output a PNG string
+  getDump() {
+    // compute adler32 of output pixels + row filter bytes
+    var BASE = 65521; /* largest prime smaller than 65536 */
+    var NMAX = 5552; /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
+    var s1 = 1;
+    var s2 = 0;
+    var n = NMAX;
+
+    for (var y = 0; y < this.height; y++) {
+      for (var x = -1; x < this.width; x++) {
+        s1 += this.buffer[this.index(x, y)].charCodeAt(0);
+        s2 += s1;
+        if ((n -= 1) == 0) {
+          s1 %= BASE;
+          s2 %= BASE;
+          n = NMAX;
+        }
+      }
+    }
+    s1 %= BASE;
+    s2 %= BASE;
+    write(
+      this.buffer,
+      this.idat_offs + this.idat_size - 8,
+      byte4((s2 << 16) | s1)
+    );
+
+    // compute crc32 of the PNG chunks
+    const crc32 = (png, offs, size) => {
+      var crc = -1;
+      for (var i = 4; i < size - 4; i += 1) {
+        crc =
+          this._crc32[(crc ^ png[offs + i].charCodeAt(0)) & 0xff] ^
+          ((crc >> 8) & 0x00ffffff);
+      }
+      write(png, offs + size - 4, byte4(crc ^ -1));
+    };
+
+    crc32(this.buffer, this.ihdr_offs, this.ihdr_size);
+    crc32(this.buffer, this.plte_offs, this.plte_size);
+    crc32(this.buffer, this.trns_offs, this.trns_size);
+    crc32(this.buffer, this.idat_offs, this.idat_size);
+    crc32(this.buffer, this.iend_offs, this.iend_size);
+
+    // convert PNG to string
+    return "\x89PNG\r\n\x1a\n" + this.buffer.join("");
+  }
+}

--- a/js/liedenticon/1.0.1/png/index.mjs
+++ b/js/liedenticon/1.0.1/png/index.mjs
@@ -1,0 +1,30 @@
+//
+import Graphic, { render } from "../graphic.mjs";
+import Image from "./image.mjs";
+const rectangle = (x, y, w, h, color, image) => {
+  for (let i = x; i < x + w; i++) {
+    for (let j = y; j < y + h; j++) {
+      image.buffer[image.index(i, j)] = color;
+    }
+  }
+};
+export default class extends Graphic {
+  renderImage(hash, size, padding, background, foreground) {
+    return render(
+      hash,
+      {
+        size,
+        padding,
+        background,
+        foreground,
+      },
+      new Image(size, size, 256),
+      rectangle
+    );
+  }
+  toString(preamble = true) {
+    return `${
+      preamble ? `data:image/png;base64,` : ""
+    }${this.image.getBase64()}`;
+  }
+}

--- a/js/liedenticon/1.0.1/readme.md
+++ b/js/liedenticon/1.0.1/readme.md
@@ -1,0 +1,124 @@
+# Liedenticon
+
+> **Source of truth:** development happens at
+> [github.com/johnhenry/liedenticon](https://github.com/johnhenry/liedenticon).
+> This directory is a snapshot published here for the CDN import URL and
+> npm release; it will not track every upstream commit.
+
+Transform a string into a unique image.
+
+Liedenticon is a refinement of
+[Identicon](https://github.com/stewartlord/identicon.js) that separates
+image generation into two classes — one for SVGs and one for PNGs — with
+flexible hex color support and percentage padding. Ships as plain ES
+modules with zero dependencies; works in Node and the browser.
+
+## Import Syntax
+
+Import directly from this site:
+
+```javascript
+import {
+  SVG,
+  PNG,
+} from "https://johnhenry.github.io/lib/js/liedenticon/1.0.1/index.mjs";
+```
+
+or install via npm (`npm install liedenticon`) and import by name:
+
+```javascript
+import { SVG, PNG } from "liedenticon";
+```
+
+## Usage
+
+### SVG
+
+By default the SVG class generates an svg string to be embedded in a
+document.
+
+```javascript
+console.log(String(new SVG("efb8c90a13f7a1fdc4910"))); // "<svg ..."
+```
+
+Passing a truthy parameter to the `toString` method creates a string that
+can be used directly as the source attribute of an image.
+
+```javascript
+new SVG("efb8c90a13f7a1fdc4910").toString(true); // "data:image/svg+xml;utf8,<svg ..."
+```
+
+Passing a second truthy parameter returns the base64-encoded string.
+
+```javascript
+new SVG("efb8c90a13f7a1fdc4910").toString(true, true); // "data:image/svg+xml;base64,..."
+```
+
+### PNG
+
+The PNG class generates a base64 string, by default with a data-URI
+preamble attached — usable directly as an image source.
+
+```javascript
+const img = document.createElement("img");
+img.src = new PNG("efb8c90a13f7a1fdc4910");
+document.body.appendChild(img);
+```
+
+Passing a falsy parameter to `toString` drops the preamble.
+
+```javascript
+new PNG("efb8c90a13f7a1fdc4910").toString(false); // raw base64
+```
+
+### Options
+
+Both classes take an options object as a second argument:
+
+```javascript
+new SVG("efb8c90a13f7a1fdc4910", {
+  size: 128, // width/height in pixels (default 64)
+  padding: "20%", // padding — number, numeric string, or percentage
+  saturation: 0.75, // derived-foreground saturation
+  brightness: 0.5, // derived-foreground brightness
+  background: [0, 0, 0, 0], // background color (default transparent)
+  foreground: "#36c", // foreground color (default derived from hash)
+});
+```
+
+#### Color Support
+
+In addition to `[r, g, b]` / `[r, g, b, a]` arrays, colors may be given as
+1, 2, 3, 4, 6, or 8 digit hex codes (with or without a leading `#`); 2, 4,
+and 8 digit codes carry an alpha channel.
+
+#### Padding vs Margin
+
+Liedenticon replaces Identicon's "margin" option with "padding", matching
+the [CSS definition](https://www.w3schools.com/cSS/css_padding.asp) most
+web developers expect; percentage strings such as `"20%"` are supported.
+
+### Extending
+
+Both classes inherit from an internal `Graphic` class. Support other
+formats by extending it and implementing `renderImage` and `toString`:
+
+```javascript
+import Graphic from "liedenticon/graphic";
+
+class NewFormat extends Graphic {
+  renderImage(hash, size, padding, background, foreground) {
+    // ...
+  }
+  toString() {
+    // ...
+  }
+}
+```
+
+## Demonstration
+
+See this module's test suite,
+[liedenticon.jest.test.mjs](./liedenticon.jest.test.mjs), for working
+examples, and the [0.0.4 demo](../0.0.4/index.html) for an in-browser
+demonstration.

--- a/js/liedenticon/1.0.1/svg/image.mjs
+++ b/js/liedenticon/1.0.1/svg/image.mjs
@@ -1,0 +1,71 @@
+//
+import colorToArray from "../color-to-array.mjs";
+export default class {
+  constructor(size, foreground, background) {
+    this.size = size;
+    this.foreground = this.color(foreground);
+    this.background = this.color(background);
+    this.rectangles = [];
+  }
+  color(input) {
+    if (typeof input !== "object") {
+      input = colorToArray(input);
+    }
+    const [r, g, b, a] = input;
+    const values = [r, g, b].map(Math.round);
+    values.push(a >= 0 && a <= 255 ? a / 255 : 1);
+    return "rgba(" + values.join(",") + ")";
+  }
+  getDump() {
+    var i,
+      xml,
+      rect,
+      fg = this.foreground,
+      bg = this.background,
+      stroke = this.size * 0.005;
+
+    xml =
+      "<svg xmlns='http://www.w3.org/2000/svg'" +
+      " width='" +
+      this.size +
+      "' height='" +
+      this.size +
+      "'" +
+      " style='background-color:" +
+      bg +
+      ";'>" +
+      "<g style='fill:" +
+      fg +
+      "; stroke:" +
+      fg +
+      "; stroke-width:" +
+      stroke +
+      ";'>";
+
+    for (i = 0; i < this.rectangles.length; i++) {
+      rect = this.rectangles[i];
+      if (rect.color == bg) continue;
+      xml +=
+        "<rect " +
+        " x='" +
+        rect.x +
+        "'" +
+        " y='" +
+        rect.y +
+        "'" +
+        " width='" +
+        rect.w +
+        "'" +
+        " height='" +
+        rect.h +
+        "'" +
+        "/>";
+    }
+    xml += "</g></svg>";
+
+    return xml;
+  }
+  getBase64() {
+    return btoa(this.getDump());
+  }
+}

--- a/js/liedenticon/1.0.1/svg/index.mjs
+++ b/js/liedenticon/1.0.1/svg/index.mjs
@@ -1,0 +1,33 @@
+//
+import Graphic, { render } from "../graphic.mjs";
+import Image from "./image.mjs";
+const rectangle = (x, y, w, h, color, image) => {
+  image.rectangles.push({ x: x, y: y, w: w, h: h, color: color });
+};
+
+export default class extends Graphic {
+  renderImage(hash, size, padding, background, foreground) {
+    return render(
+      hash,
+      {
+        size,
+        padding,
+        background,
+        foreground,
+      },
+      new Image(size, foreground, background),
+      rectangle
+    );
+  }
+  toString(preamble = false, base64 = false) {
+    if (base64) {
+      return `${
+        preamble ? "data:image/svg+xml;base64," : ""
+      }${this.image.getBase64()}`;
+    } else {
+      return `${
+        preamble ? "data:image/svg+xml;utf8," : ""
+      }${this.image.getDump()}`;
+    }
+  }
+}


### PR DESCRIPTION
## Why
Same situation as pop-quiz (#12): `johnhenry/liedenticon` is a separate repo. Turned out to be low-stakes — it never moved past 0.0.4, and its only post-0.0.4 commits are two doc typo fixes already present by the time this module was vendored into lib.

## What
Metadata/docs-only `1.0.1` (no code changes): lib's `1.0.0/graphic.mjs` already has better hash validation (reject non-strings, pad short hashes) than the standalone repo — that fix is proposed the other direction in [johnhenry/liedenticon#1](https://github.com/johnhenry/liedenticon/pull/1). This PR just fixes `package.json`'s license field (was `ISC`, should be `MIT`) and points `homepage`/`repository`/readme at github.com/johnhenry/liedenticon as the source of truth.

## Verification
14/14 tests pass. `npm run build && node scripts/verify-contract.mjs` green — 977 paths intact, one new additive URL.